### PR TITLE
fix(build): allow building tagging tools on macos with clang

### DIFF
--- a/tagging_tools/elf_code
+++ b/tagging_tools/elf_code
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tagging_tools/gen_tag_info
+++ b/tagging_tools/gen_tag_info
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import tempfile

--- a/tagging_tools/md_asm_ann.cc
+++ b/tagging_tools/md_asm_ann.cc
@@ -37,12 +37,23 @@
 
 using namespace policy_engine;
 
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
-
-#if GCC_VERSION < 40900
-  #include "make_unique.h"
+#if defined(__clang__)
+  // Clang pretends to be __GNUC__ 4.2.1; make_unique seems to be
+  // supported on clang 3.4+.
+  #define CLANG_VERSION (__clang_major__ * 10000 \
+                          + __clang_minor__ * 100 \
+                          + __clang_patchlevel__)
+  #if CLANG_VERSION < 30400
+    #include "make_unique.h"
+  #endif
+#elif defined(__GNUC__)
+  #define GCC_VERSION (__GNUC__ * 10000 \
+                          + __GNUC_MINOR__ * 100 \
+                          + __GNUC_PATCHLEVEL__)
+  
+  #if GCC_VERSION < 40900
+    #include "make_unique.h"
+  #endif
 #endif
 
 class annotater_t : public asm_annotater_t {

--- a/tagging_tools/symbol_table.h
+++ b/tagging_tools/symbol_table.h
@@ -29,6 +29,7 @@
 
 #include <map>
 #include <list>
+#include <string>
 #include <algorithm>
 
 #include "platform_types.h"


### PR DESCRIPTION
Also fix Python script's shebang to search for interpreter in PATH.

This was tested using clang-902.0.39.1 on macOS 10.13.4.