### PR TITLE
Gen tag info changes based on Dover feedback

### DIFF
--- a/Makefile.isp
+++ b/Makefile.isp
@@ -28,6 +28,7 @@ install: all
 	install -p tagging_tools/TaggingUtils.py $(ISP_PREFIX)/bin/
 	install -p tagging_tools/OpCodeTagger.py $(ISP_PREFIX)/bin/
 	install -p tagging_tools/RWXTagger.py $(ISP_PREFIX)/bin/
+	install -p tagging_tools/ELFMetadataTagger.py $(ISP_PREFIX)/bin/
 	install -p scripts/run_riscv $(ISP_PREFIX)/bin/
 	install -p scripts/run_riscv_gdb $(ISP_PREFIX)/bin/
 	install -p build/librv32-renode-validator.so $(ISP_PREFIX)/lib/

--- a/tagging_tools/ELFMetadataTagger.py
+++ b/tagging_tools/ELFMetadataTagger.py
@@ -1,0 +1,186 @@
+import TaggingUtils
+import logging
+import sys
+
+PTR_SIZE = 4
+
+metadata_ops = {
+    "DMD_SET_BASE_ADDRESS_OP": 0x01,
+    "DMD_TAG_ADDRESS_OP": 0x02,
+    "DMD_TAG_ADDRESS_RANGE_OP": 0x03,
+    "DMD_TAG_POLICY_SYMBOL": 0x04,
+    "DMD_TAG_POLICY_RANGE": 0x05,
+    "DMD_TAG_POLICY_SYMBOL_RANKED": 0x06,
+    "DMD_TAG_POLICY_RANGE_RANKED": 0x07,
+    "DMD_END_BLOCK": 0x08,
+    "DMD_END_BLOCK_WEAK_DECL_HACK": 0x09,
+    "DMD_FUNCTION_RANGE": 0xa
+}
+
+tag_specifiers = {
+    "DMT_CFI3L_VALID_TGT": 0x01,
+    "DMT_STACK_PROLOGUE_AUTHORITY": 0x02,
+    "DMT_STACK_EPILOGUE_AUTHORITY": 0x03,
+    "DMT_FPTR_STORE_AUTHORITY": 0x04,
+    "DMT_BRANCH_VALID_TGT": 0x05,
+    "DMT_RET_VALID_TGT": 0x06,
+    "DMT_RETURN_INSTR": 0x07,
+    "DMT_CALL_INSTR": 0x08,
+    "DMT_BRANCH_INSTR": 0x09,
+    "DMT_FPTR_CREATE_AUTHORITY": 0x0a
+}
+
+policy_map = {
+    "threeClass": {
+        "call-tgt": {
+            "tag_specifier": tag_specifiers["DMT_CFI3L_VALID_TGT"],
+            "policy_name": "llvm.CFI_Call-Tgt"
+        },
+        "branch-tgt": {
+            "tag_specifier": tag_specifiers["DMT_BRANCH_VALID_TGT"],
+            "policy_name": "llvm.CFI_Branch-Tgt"
+        },
+        "return-tgt": {
+            "tag_specifier": tag_specifiers["DMT_RET_VALID_TGT"],
+            "policy_name": "llvm.CFI_Return-Tgt"
+        },
+        "call-instr": {
+            "tag_specifier": tag_specifiers["DMT_CALL_INSTR"],
+            "policy_name": "llvm.CFI_Call-Instr"
+        },
+        "branch-instr": {
+            "tag_specifier": tag_specifiers["DMT_BRANCH_INSTR"],
+            "policy_name": "llvm.CFI_Branch-Instr"
+        },
+        "return-instr": {
+            "tag_specifier": tag_specifiers["DMT_RETURN_INSTR"],
+            "policy_name": "llvm.CFI_Return-Instr"
+        }
+    },
+    "cpi": {
+        "fptrcreate": {
+            "tag_specifier": tag_specifiers["DMT_FPTR_CREATE_AUTHORITY"],
+            "policy_name": "llvm.CPI.FPtrCreate"
+        },
+        "fptrstore": {
+            "tag_specifier": tag_specifiers["DMT_FPTR_STORE_AUTHORITY"],
+            "policy_name": "llvm.CPI.FPtrStore"
+        },
+        "return-instr": {
+            "tag_specifier": tag_specifiers["DMT_RETURN_INSTR"],
+            "policy_name": "llvm.CFI_Return-Instr"
+        }
+    },
+    "cfi": {
+        "target": {
+            "tag_specifier": tag_specifiers["DMT_CFI3L_VALID_TGT"],
+            "policy_name": "dover.Tools.GCC.CFI_Target"
+        }
+    },
+    "stack": {
+        "prologue": {
+            "tag_specifier": tag_specifiers["DMT_STACK_PROLOGUE_AUTHORITY"],
+            "policy_name": "dover.Tools.GCC.Prologue"
+        },
+        "epilogue": {
+            "tag_specifier": tag_specifiers["DMT_STACK_EPILOGUE_AUTHORITY"],
+            "policy_name": "dover.Tools.GCC.Epilogue"
+        }
+    }
+}
+
+
+def bytes_to_uint(it, size):
+    data = []
+    for _ in range(size):
+        data.append(next(it))
+    return int.from_bytes(data, byteorder='little', signed=False)
+
+
+def check_and_write_range(range_file, start, end, tag_specifier,
+                          policy, range_map=None):
+    policy_mappings = policy_map[policy]
+    for policy, tags in policy_mappings.items():
+        if tags['tag_specifier'] == tag_specifier:
+            range_file.write_range(start, end, tags['policy_name'])
+            if range_map:
+                range_map.add_range(start, end, tags['policy_name'])
+
+
+def generate_policy_ranges(ef, range_file, policy):
+    metadata = ef.get_section_by_name(b'.dover_metadata')
+    if not metadata:
+        metadata = ef.get_section_by_name(".dover_metadata")
+    metadata = metadata.data()
+    assert metadata[0] == metadata_ops['DMD_SET_BASE_ADDRESS_OP'], "Invalid metadata found in ELF file!"
+
+    it = iter(metadata)
+
+    if policy == "cfi" or policy == "threeClass":
+        range_map = TaggingUtils.RangeMap()
+    else:
+        range_map = None
+
+    for byte in it:
+        if (byte == metadata_ops['DMD_SET_BASE_ADDRESS_OP']):
+            base_address = bytes_to_uint(it, 8) #apparently GCC emits a 64-bit base
+            logging.debug("new base address is " + hex(base_address) + "\n")
+        elif (byte == metadata_ops['DMD_TAG_ADDRESS_OP']):
+            address = bytes_to_uint(it, PTR_SIZE) + base_address
+            tag_specifier = bytes_to_uint(it, 1)
+            logging.debug("tag is " + hex(tag_specifier) +
+                          " at address " + hex(address) + '\n')
+
+            check_and_write_range(range_file, address, address + PTR_SIZE, tag_specifier,
+                                  policy, range_map)
+
+        elif (byte == metadata_ops['DMD_TAG_ADDRESS_RANGE_OP']):
+            start_address = bytes_to_uint(it, PTR_SIZE) + base_address
+            end_address = bytes_to_uint(it, PTR_SIZE) + base_address
+            tag_specifier = bytes_to_uint(it, 1)
+            logging.debug("tag is " + hex(tag_specifier) +
+                          " for address range " +
+                          hex(start_address) + ":" + hex(end_address) + '\n')
+
+            check_and_write_range(range_file, start_address, end_address, tag_specifier,
+                                  policy, range_map)
+
+        elif (byte == metadata_ops['DMD_TAG_POLICY_SYMBOL']):
+            logging.critical("Saw policy symbol!\n")
+            sys.exit(-1)
+        elif (byte == metadata_ops['DMD_TAG_POLICY_RANGE']):
+            logging.critical("Saw policy range!\n")
+            sys.exit(-1)
+            for _ in range(PTR_SIZE*3):
+                #skip start, end, & 32-bit tag-type
+                next(it)
+        elif (byte == metadata_ops['DMD_TAG_POLICY_SYMBOL_RANKED']):
+            logging.critical("Saw policy symbol ranked\n")
+            sys.exit(-1)
+        elif (byte == metadata_ops['DMD_TAG_POLICY_RANGE_RANKED']):
+            sys.exit(-1)
+            logging.critical("Saw policy symbol range ranked\n")
+            #skip start, end ,tag category, rank, tag type
+            for _ in range(PTR_SIZE*5):
+                next(it)
+        elif (byte == metadata_ops['DMD_END_BLOCK_WEAK_DECL_HACK']):
+            logging.critical("saw end weak decl tag!\n")
+            sys.exit(-1)
+        elif (byte == metadata_ops['DMD_END_BLOCK']):
+            end_address = bytes_to_uint(it, PTR_SIZE)
+            logging.debug("saw end block tag range = " + hex(base_address) +
+                          ":" + hex(base_address + end_address))
+            if range_map:
+                range_map.add_range(base_address, base_address + end_address, "COMPILER_GENERATED")
+        elif (byte == metadata_ops['DMD_FUNCTION_RANGE']):
+            start_address = bytes_to_uint(it, PTR_SIZE) + base_address
+            end_address = bytes_to_uint(it, PTR_SIZE) + base_address + PTR_SIZE
+            logging.debug("saw function range = " + hex(start_address) +
+                          ":" + hex(end_address))
+            if range_map:
+                range_map.add_range(start_address, end_address, "COMPILER_GENERATED")
+        else:
+            logging.debug("Error: found unknown byte in metadata!" + hex(byte) + "\n")
+            sys.exit(-1)
+
+    return range_map

--- a/tagging_tools/gen_tag_info
+++ b/tagging_tools/gen_tag_info
@@ -9,6 +9,7 @@ import logging
 import TaggingUtils
 import RWXTagger
 import OpCodeTagger
+import ELFMetadataTagger
 import yaml
 
 from elftools.elf.elffile import ELFFile
@@ -20,95 +21,7 @@ md_code = 'md_code'
 md_asm_ann = 'md_asm_ann'
 md_entity = 'md_entity'
 
-PTR_SIZE = 4
-
-CFI = 'dover.Tools.GCC.CFI_Target'
 NoCFI = 'dover.Tools.GCC.NoCFI'
-
-metadata_ops = {
-    "DMD_SET_BASE_ADDRESS_OP": 0x01,
-    "DMD_TAG_ADDRESS_OP": 0x02,
-    "DMD_TAG_ADDRESS_RANGE_OP": 0x03,
-    "DMD_TAG_POLICY_SYMBOL": 0x04,
-    "DMD_TAG_POLICY_RANGE": 0x05,
-    "DMD_TAG_POLICY_SYMBOL_RANKED": 0x06,
-    "DMD_TAG_POLICY_RANGE_RANKED": 0x07,
-    "DMD_END_BLOCK": 0x08,
-    "DMD_END_BLOCK_WEAK_DECL_HACK": 0x09,
-    "DMD_FUNCTION_RANGE": 0xa
-}
-
-tag_specifiers = {
-    "DMT_CFI3L_VALID_TGT": 0x01,
-    "DMT_STACK_PROLOGUE_AUTHORITY": 0x02,
-    "DMT_STACK_EPILOGUE_AUTHORITY": 0x03,
-    "DMT_FPTR_STORE_AUTHORITY": 0x04,
-    "DMT_BRANCH_VALID_TGT": 0x05,
-    "DMT_RET_VALID_TGT": 0x06,
-    "DMT_RETURN_INSTR": 0x07,
-    "DMT_CALL_INSTR": 0x08,
-    "DMT_BRANCH_INSTR": 0x09,
-    "DMT_FPTR_CREATE_AUTHORITY": 0x0a
-}
-
-policy_map = {
-    "threeClass": {
-        "call-tgt": {
-            "tag_specifier": tag_specifiers["DMT_CFI3L_VALID_TGT"],
-            "policy_name": "llvm.CFI_Call-Tgt"
-        },
-        "branch-tgt": {
-            "tag_specifier": tag_specifiers["DMT_BRANCH_VALID_TGT"],
-            "policy_name": "llvm.CFI_Branch-Tgt"
-        },
-        "return-tgt": {
-            "tag_specifier": tag_specifiers["DMT_RET_VALID_TGT"],
-            "policy_name": "llvm.CFI_Return-Tgt"
-        },
-        "call-instr": {
-            "tag_specifier": tag_specifiers["DMT_CALL_INSTR"],
-            "policy_name": "llvm.CFI_Call-Instr"
-        },
-        "branch-instr": {
-            "tag_specifier": tag_specifiers["DMT_BRANCH_INSTR"],
-            "policy_name": "llvm.CFI_Branch-Instr"
-        },
-        "return-instr": {
-            "tag_specifier": tag_specifiers["DMT_RETURN_INSTR"],
-            "policy_name": "llvm.CFI_Return-Instr"
-        }
-    },
-    "cpi": {
-        "fptrcreate": {
-            "tag_specifier": tag_specifiers["DMT_FPTR_CREATE_AUTHORITY"],
-            "policy_name": "llvm.CPI.FPtrCreate"
-        },
-        "fptrstore": {
-            "tag_specifier": tag_specifiers["DMT_FPTR_STORE_AUTHORITY"],
-            "policy_name": "llvm.CPI.FPtrStore"
-        },
-        "return-instr": {
-            "tag_specifier": tag_specifiers["DMT_RETURN_INSTR"],
-            "policy_name": "llvm.CFI_Return-Instr"
-        }
-    },
-    "cfi": {
-        "target": {
-            "tag_specifier": tag_specifiers["DMT_CFI3L_VALID_TGT"],
-            "policy_name": "dover.Tools.GCC.CFI_Target"
-        }
-    },
-    "stack": {
-        "prologue": {
-            "tag_specifier": tag_specifiers["DMT_STACK_PROLOGUE_AUTHORITY"],
-            "policy_name": "dover.Tools.GCC.Prologue"
-        },
-        "epilogue": {
-            "tag_specifier": tag_specifiers["DMT_STACK_EPILOGUE_AUTHORITY"],
-            "policy_name": "dover.Tools.GCC.Epilogue"
-        }
-    }
-}
 
 
 def policy_has_module(yf, name):
@@ -117,13 +30,6 @@ def policy_has_module(yf, name):
         if m["name"] == name:
             return True
     return False
-
-
-def bytes_to_uint(it, size):
-    data = []
-    for _ in range(size):
-        data.append(next(it))
-    return int.from_bytes(data, byteorder='little', signed=False)
 
 
 def round_up(x, align):
@@ -136,126 +42,20 @@ def add_code_section_ranges(ef, range_map):
         if (flags & SH_FLAGS.SHF_ALLOC):
             start = s['sh_addr']
             end = start + s['sh_size']
-            end = round_up(end, PTR_SIZE)
+            end = round_up(end, ELFMetadataTagger.PTR_SIZE)
             if ((flags & (SH_FLAGS.SHF_ALLOC | SH_FLAGS.SHF_WRITE | SH_FLAGS.SHF_EXECINSTR)) ==
                 (SH_FLAGS.SHF_ALLOC | SH_FLAGS.SHF_EXECINSTR)):
                 range_map.add_range(start, end)
 
 
-def parse_asm_symbols(ef, range_file):
-    section = ef.get_section_by_name('.symtab')
-    if isinstance(section, SymbolTableSection):
-        for symbol in section.iter_symbols():
-            if symbol.entry['st_size'] == 0 and symbol.entry['st_name'] != 0:
-                shndx = symbol.entry['st_shndx']
-                if shndx == "SHN_ABS" or shndx == "SHN_UNDEF" or shndx == "SHN_COMMON":
-                    continue
-                # else:
-                #     symsec = ef.get_section(shndx)
-                #     base_address = symsec['sh_addr']
-                # address = base_address + symbol.entry['st_value']
-                address = symbol.entry['st_value']
-                logging.debug(symbol.name + "addr=" + hex(address))
-                range_file.write_range(address, address + PTR_SIZE, CFI)
-
-
-def check_and_write_range(range_file, start, end, tag_specifier,
-                          policy, range_map=None):
-    policy_mappings = policy_map[policy]
-    for policy, tags in policy_mappings.items():
-        if tags['tag_specifier'] == tag_specifier:
-            range_file.write_range(start, end, tags['policy_name'])
-            if range_map:
-                range_map.add_range(start, end, tags['policy_name'])
-
-
-def generate_policy_ranges(ef, range_file, policy):
-    metadata = ef.get_section_by_name(b'.dover_metadata')
-    if not metadata:
-        metadata = ef.get_section_by_name(".dover_metadata")
-    metadata = metadata.data()
-    assert metadata[0] == metadata_ops['DMD_SET_BASE_ADDRESS_OP'], "Invalid metadata found in ELF file!"
-
-    it = iter(metadata)
-
-    if policy == "cfi" or policy == "threeClass":
-        range_map = TaggingUtils.RangeMap()
-    else:
-        range_map = None
-
-    for byte in it:
-        if (byte == metadata_ops['DMD_SET_BASE_ADDRESS_OP']):
-            base_address = bytes_to_uint(it, 8) #apparently GCC emits a 64-bit base
-            logging.debug("new base address is " + hex(base_address) + "\n")
-        elif (byte == metadata_ops['DMD_TAG_ADDRESS_OP']):
-            address = bytes_to_uint(it, PTR_SIZE) + base_address
-            tag_specifier = bytes_to_uint(it, 1)
-            logging.debug("tag is " + hex(tag_specifier) +
-                          " at address " + hex(address) + '\n')
-
-            check_and_write_range(range_file, address, address + PTR_SIZE, tag_specifier,
-                                  policy, range_map)
-
-        elif (byte == metadata_ops['DMD_TAG_ADDRESS_RANGE_OP']):
-            start_address = bytes_to_uint(it, PTR_SIZE) + base_address
-            end_address = bytes_to_uint(it, PTR_SIZE) + base_address
-            tag_specifier = bytes_to_uint(it, 1)
-            logging.debug("tag is " + hex(tag_specifier) +
-                          " for address range " +
-                          hex(start_address) + ":" + hex(end_address) + '\n')
-
-            check_and_write_range(range_file, start_address, end_address, tag_specifier,
-                                  policy, range_map)
-
-        elif (byte == metadata_ops['DMD_TAG_POLICY_SYMBOL']):
-            logging.critical("Saw policy symbol!\n")
-            sys.exit(-1)
-        elif (byte == metadata_ops['DMD_TAG_POLICY_RANGE']):
-            logging.critical("Saw policy range!\n")
-            sys.exit(-1)
-            for _ in range(PTR_SIZE*3):
-                #skip start, end, & 32-bit tag-type
-                next(it)
-        elif (byte == metadata_ops['DMD_TAG_POLICY_SYMBOL_RANKED']):
-            logging.critical("Saw policy symbol ranked\n")
-            sys.exit(-1)
-        elif (byte == metadata_ops['DMD_TAG_POLICY_RANGE_RANKED']):
-            sys.exit(-1)
-            logging.critical("Saw policy symbol range ranked\n")
-            #skip start, end ,tag category, rank, tag type
-            for _ in range(PTR_SIZE*5):
-                next(it)
-        elif (byte == metadata_ops['DMD_END_BLOCK_WEAK_DECL_HACK']):
-            logging.critical("saw end weak decl tag!\n")
-            sys.exit(-1)
-        elif (byte == metadata_ops['DMD_END_BLOCK']):
-            end_address = bytes_to_uint(it, PTR_SIZE)
-            logging.debug("saw end block tag range = " + hex(base_address) +
-                          ":" + hex(base_address + end_address))
-            if range_map:
-                range_map.add_range(base_address, base_address + end_address, "COMPILER_GENERATED")
-        elif (byte == metadata_ops['DMD_FUNCTION_RANGE']):
-            start_address = bytes_to_uint(it, PTR_SIZE) + base_address
-            end_address = bytes_to_uint(it, PTR_SIZE) + base_address + PTR_SIZE
-            logging.debug("saw function range = " + hex(start_address) +
-                          ":" + hex(end_address))
-            if range_map:
-                range_map.add_range(start_address, end_address, "COMPILER_GENERATED")
-        else:
-            logging.debug("Error: found unknown byte in metadata!" + hex(byte) + "\n")
-            sys.exit(-1)
-
-    return range_map
-
-
 def generate_cfi_ranges(ef, range_file):
     code_range_map = TaggingUtils.RangeMap()
     add_code_section_ranges(ef, code_range_map)
-    range_map = generate_policy_ranges(ef, range_file, "cfi")
+    range_map = ELFMetadataTagger.generate_policy_ranges(ef, range_file, "cfi")
 
     for (start, end, tags) in code_range_map:
-        for s in range(start, end, PTR_SIZE):
-            e = s + PTR_SIZE
+        for s in range(start, end, ELFMetadataTagger.PTR_SIZE):
+            e = s + ELFMetadataTagger.PTR_SIZE
             if (s, e, tags) not in range_map:
                 range_file.write_range(s, e, NoCFI)
 
@@ -270,7 +70,7 @@ def write_section_range(ef, range_file, section_name, tag):
 
 
 def generate_stack_ranges(ef, range_file):
-    generate_policy_ranges(ef, range_file, "stack")
+    ELFMetadataTagger.generate_policy_ranges(ef, range_file, "stack")
 
 
 def generate_rwx_ranges(ef, range_file):
@@ -278,18 +78,17 @@ def generate_rwx_ranges(ef, range_file):
 
 
 def generate_cpi_ranges(ef, range_file):
-    generate_policy_ranges(ef, range_file, "cpi")
-    #parse_asm_symbols(ef, range_file)
+    ELFMetadataTagger.generate_policy_ranges(ef, range_file, "cpi")
 
 
 def generate_threeClass_ranges(ef, range_file):
     code_range_map = TaggingUtils.RangeMap()
     add_code_section_ranges(ef, code_range_map)
-    range_map = generate_policy_ranges(ef, range_file, "threeClass")
+    range_map = ELFMetadataTagger.generate_policy_ranges(ef, range_file, "threeClass")
 
     for (start, end, tags) in code_range_map:
-        for s in range(start, end, PTR_SIZE):
-            e = s + PTR_SIZE
+        for s in range(start, end, ELFMetadataTagger.PTR_SIZE):
+            e = s + ELFMetadataTagger.PTR_SIZE
             if (s, e, tags) not in range_map:
                 range_file.write_range(s, e, NoCFI)
 
@@ -303,8 +102,6 @@ def main():
                         help="File to output tag info")
     parser.add_argument("-b", "--bin", action="store", required=True,
                         help="Program binary to parse for tags")
-    parser.add_argument("-p", "--policies", action="store", required=True,
-                        help="Policy string to generate tags for (e.g. osv.frtos.main.cfi-rwx))")
     parser.add_argument("--log", action="store", default='WARNING',
                         help="Logging level (DEBUG, WARNING, INFO)")
     parser.add_argument("-e", "--entities", nargs='+', default=[],
@@ -337,7 +134,7 @@ def main():
         range_file = TaggingUtils.RangeFile()
 
         module_policies = [module['name'].split('.')[-1] for module in policy_modules['Modules']]
-        policies = args.policies.split('.')[-1].split('-')
+        policies = args.policy_dir.split('.')[-1].split('-')
 
         for policy in policies:
             if policy not in module_policies:


### PR DESCRIPTION
- Separate out the ELF metadata parsing to another file.
- Don't need policies argument since policy directory name has all the info needed.