### PR TITLE
A finite cache fix and a related validator fix, plus some documentation.

### DIFF
--- a/validator/riscv/rv32_validator.cc
+++ b/validator/riscv/rv32_validator.cc
@@ -85,6 +85,7 @@ void rv32_validator_t::handle_violation(context_t *ctx, operands_t *ops){
 void rv32_validator_base_t::setup_validation() {
   memset(ctx, 0, sizeof(*ctx));
   memset(ops, 0, sizeof(*ops));
+  ctx->cached=true;
 
   if (res->pcResult) {
     memset(res->pc, 0, sizeof(meta_set_t));
@@ -153,7 +154,6 @@ bool rv32_validator_t::validate(address_t pc, insn_bits_t insn) {
   int policy_result = POLICY_EXP_FAILURE;
 
   setup_validation();
-  
   prepare_eval(pc, insn);
   if (rule_cache) {
     if (rule_cache->allow(ops, res)) {
@@ -255,7 +255,10 @@ bool rv32_validator_t::commit() {
       .rdResult = res->rdResult,
       .csrResult = res->csrResult
     };
-    rule_cache->install_rule(ops, &res_copy);
+
+    if (ctx->cached && !rule_cache->allow(ops, res)) {
+      rule_cache->install_rule(ops, &res_copy);
+    }
   }
   return hit_watch;
 }
@@ -297,6 +300,7 @@ void rv32_validator_t::prepare_eval(address_t pc, insn_bits_t insn) {
   
   memset(ctx, 0, sizeof(*ctx));
   memset(ops, 0, sizeof(*ops));
+  ctx->cached=true;
 
   if(res->pcResult){
     memset(res->pc, 0, sizeof(meta_set_t));

--- a/validator/rule_cache/finite_rule_cache/finite_rule_cache.h
+++ b/validator/rule_cache/finite_rule_cache/finite_rule_cache.h
@@ -17,9 +17,22 @@ public:
   bool allow(operands_t *ops, results_t *res);
 
 private:
+  // the number of rules the cache can hold.
   int capacity;
-  operands_t **entries;
-  bool *entry_used;
+
+  // We track whether the cache is full so that we know when to begin evicting
+  // elements upon insertion.  The cache is ideal in the sense that the oldest
+  // element is always the one evicted.
+  bool cache_full;
+
+  // The keys of the elements currently in the cache.
+  // The oldest entry in the cache is:
+  //   - entries[0] if cache_full is false
+  //   - entries[(next_entry+1)%capacity] if cache_full is true
+  operands_t *entries;
+
+  // the next location into which we will insert an entry in the "entries"
+  // array.
   int next_entry;
 };
 


### PR DESCRIPTION
1) The finite cache was completely broken.  In particular, the way it kept track of
what to evict from the cache next relied on false assumptions about the pointers
the validator handed it.  The finite cache assumed that the pointers were
basically const, but the validator reused the memory.

2) The validator was not correctly checking whether each policy result should be
cached.  This causes problems for policies like heap, where some rules must not
be cached.  When using heap with a sufficiently large cache, this bug would
result in the use of a single color everywhere, because the rule that was
supposed to generate new colors each time it fired got cached and only fired
once.