### PR TITLE
Add TMT entry ranges to taginfo header

### DIFF
--- a/tagging_tools/ELFSectionTagger.py
+++ b/tagging_tools/ELFSectionTagger.py
@@ -23,17 +23,3 @@ def generate_rwx_ranges(ef, range_file):
           elif flags & SH_FLAGS.SHF_ALLOC:
                range_file.write_range(start, end, RWX_R)
                print('R {0}: 0x{1:X}'.format(s.name, start))
-
-def get_memory_ranges(ef):
-    code_range = (0, 0)
-    data_range = (0, 0)
-    for s in ef.iter_sections():
-        flags = s['sh_flags']
-        start = s['sh_addr']
-        end = start + s['sh_size']
-        if flags & SH_FLAGS.SHF_EXECINSTR:
-            code_range = (start, end)
-        elif flags & SH_FLAGS.SHF_WRITE:
-            data_range = (start, end)
-
-    return (code_range, data_range)

--- a/tagging_tools/elf_loader.h
+++ b/tagging_tools/elf_loader.h
@@ -56,6 +56,7 @@ public:
   ~elf_image_t();
   bool load();//bool load_symbols = false, bool load_phdrs = true);
   uintptr_t get_entry_point() const;
+  Elf_Ehdr get_ehdr() const { return eh; }
   Elf_Phdr const* get_phdrs() const { return phdrs; }
   int get_phdr_count() const { return eh.e_phnum; }
   Elf_Shdr const* get_shdrs() const { return shdrs; }

--- a/tagging_tools/elf_utils.cc
+++ b/tagging_tools/elf_utils.cc
@@ -53,3 +53,21 @@ void policy_engine::populate_symbol_table(symbol_table_t *symtab, elf_image_t *i
   }
 }
 
+void policy_engine::get_elf_sections(elf_image_t *img,
+                                     std::list<Elf_Shdr const *>&code_sections,
+                                     std::list<Elf_Shdr const *>&data_sections) {
+  Elf_Shdr const *shdrs = img->get_shdrs();
+  size_t i;
+  unsigned int flags;
+
+  for(i = 0; i < img->get_shdr_count(); i++) {
+     if (shdrs[i].sh_flags & SHF_ALLOC) {
+      flags = shdrs[i].sh_flags;
+      if ((flags & (SHF_WRITE | SHF_EXECINSTR)) == (SHF_EXECINSTR)) {
+        code_sections.push_back(&shdrs[i]);
+      } else {
+        data_sections.push_back(&shdrs[i]);
+      }
+    }
+  }
+}

--- a/tagging_tools/elf_utils.h
+++ b/tagging_tools/elf_utils.h
@@ -33,6 +33,8 @@
 namespace policy_engine {
 
 void populate_symbol_table(symbol_table_t *symtab, elf_image_t *img);
+void get_elf_sections(elf_image_t *img, std::list<Elf_Shdr const *>&code_sections,
+                      std::list<Elf_Shdr const *>&data_sections);
 
 } // namespace policy_engine
 

--- a/tagging_tools/gen_tag_info
+++ b/tagging_tools/gen_tag_info
@@ -36,9 +36,8 @@ def main():
     parser.add_argument("-e", "--entities", nargs='+', default=[],
                         required=False,
                         help="Entities file for policy")
-    parser.add_argument("-H", "--hardware", action="store_true",
-                        required=False,
-                        help="Format the tag file for use on the PEX hardware")
+    parser.add_argument("-s", "--soc-file", required=False,
+                        help="SOC config file. If present, write TMT headers for PEX firmware")
 
     args = parser.parse_args()
 
@@ -112,9 +111,8 @@ def main():
             sys.exit(presult)
 
         # Prepend host address ranges for instructions/data
-        if args.hardware == True:
-            code_range, data_range = ELFSectionTagger.get_memory_ranges(ef)
-            presult = subprocess.call([md_header, str(code_range[0]), str(code_range[1]), str(data_range[0]), str(data_range[1]), args.tag_file])
+        if args.soc_file is not None:
+            presult = subprocess.call([md_header, args.bin, args.soc_file, args.tag_file])
             if presult != 0:
                 sys.exit(presult)
 

--- a/tagging_tools/tag_file.h
+++ b/tagging_tools/tag_file.h
@@ -29,14 +29,16 @@
 
 #include <string>
 #include "metadata_memory_map.h"
+#include "elf_utils.h"
 
 namespace policy_engine {
 
 bool load_tags(metadata_memory_map_t *map, std::string file_name);
 bool save_tags(metadata_memory_map_t *map, std::string file_name);
-bool write_headers(std::pair<uintptr_t, uintptr_t> code_range,
-                   std::pair<uintptr_t, uintptr_t> data_range,
-                   bool is_64_bit, std::string file_name);
+bool write_headers(std::list<Elf_Shdr const *> &code_sections,
+                   std::list<Elf_Shdr const *> &data_sections,
+                   std::list<range_t> &soc_ranges, bool is_64_bit,
+                   std::string tag_filename);
 
 } // namespace policy_engine
 


### PR DESCRIPTION
Add a list of contiguous code/data address ranges to the taginfo header for use in initializing the TMTs in the PEX firmware