### PR TITLE
Filter out unused SOC element from TMT

### DIFF
--- a/soc_cfg/gfe-vcu118.yml
+++ b/soc_cfg/gfe-vcu118.yml
@@ -30,19 +30,19 @@ SOC:
     heterogeneous: false
   }
   ETHERNET: {
-    name: SOC.Memory.Ethernet_0,
+    name: SOC.IO.Ethernet_0,
     start: 0x62100000,
     end:   0x6213ffff,
     heterogeneous: false
   }
   FLASH0: {
-    name: SOC.IO.QSPI_0,
+    name: SOC.Memory.QSPI_0,
     start: 0x40000000,
     end:   0x4fffffff,
     heterogeneous: false
   }
   FLASH1: {
-    name: SOC.IO.QSPI_0,
+    name: SOC.Memory.QSPI_0,
     start: 0x62400000,
     end:   0x62400fff,
     heterogeneous: false
@@ -72,7 +72,7 @@ SOC:
     heterogeneous: false
     }
   SPI: {
-    name: SOC.IO.QSPI_1,
+    name: SOC.Memory.QSPI_1,
     start: 0x62320000,
     end:   0x62320fff,
     heterogeneous: false

--- a/tagging_tools/gen_tag_info
+++ b/tagging_tools/gen_tag_info
@@ -134,7 +134,7 @@ def main():
                 print("md_index failed")
                 sys.exit(presult)
 
-            presult = subprocess.call([md_header, args.bin, args.soc_file, args.tag_file] + soc_exclude)
+            presult = subprocess.call([md_header, args.bin, args.soc_file, args.tag_file, args.policy_dir] + soc_exclude)
             if presult != 0:
                 print("md_header failed")
                 sys.exit(presult)


### PR DESCRIPTION
md_header was not checking whether an SOC element was in use by the policy before adding it as a TMT entry, causing the creation of some uninitialized regions of tag memory.
Also fixes some SOC element names in the GFE config.
Depends on the RWX policy init section update in https://github.com/draperlaboratory/hope-policies/pull/87