### PR TITLE
tagging tools - off-by-one fix

### DIFF
--- a/tagging_tools/LLVMMetadataTagger.py
+++ b/tagging_tools/LLVMMetadataTagger.py
@@ -190,7 +190,7 @@ class LLVMMetadataTagger:
                 range_map.add_range(base_address, base_address + end_address, "COMPILER_GENERATED")
             elif (byte == self.metadata_ops['DMD_FUNCTION_RANGE']):
                 start_address = bytes_to_uint(it, self.PTR_SIZE) + base_address
-                end_address = bytes_to_uint(it, self.PTR_SIZE) + base_address + self.PTR_SIZE
+                end_address = bytes_to_uint(it, self.PTR_SIZE) + base_address
                 logging.debug("saw function range = " + hex(start_address) +
                             ":" + hex(end_address))
                 range_map.add_range(start_address, end_address, "COMPILER_GENERATED")


### PR DESCRIPTION
This fixes an off-by-one type error where function tags were carried over past the end of the function, and also speeds up tagging for LLVM tags.

Future work is likely still needed to handle NoCFI well.