### PR TITLE
tag granularity changes

### DIFF
--- a/soc_cfg/README.md
+++ b/soc_cfg/README.md
@@ -25,3 +25,8 @@ specifies to the validator that for the address range specified, there may end u
 multiple different tags over time.  Initially they will be all set to the one initial tag.
 Elements that have a `false` for the `heterogeneous` field will be assumed to have one and
 only one tag for the entire address range.
+
+On 32-bit platforms, everything is tagged at 32-bit granularity. On 64-bit
+systems, instructions are tagged at 32-bit and data is tagged, by default, at
+64-bit. This can be overridden by setting the `tag_granularity` field for a
+region to the correct number of bytes.

--- a/soc_cfg/sel4_hifive_cfg.yml
+++ b/soc_cfg/sel4_hifive_cfg.yml
@@ -39,6 +39,7 @@ SOC:
     name: SOC.Memory.Ram_0,
     start: 0x80000000,
     end:   0xffffffff,
+    tag_granularity: 4,
     heterogeneous: true
     }
   AON: {

--- a/soc_cfg/sel4_hifive_cfg.yml
+++ b/soc_cfg/sel4_hifive_cfg.yml
@@ -1,6 +1,6 @@
 SOC:
-  ALT_UART0: {
-    name: SOC.IO.ALT_UART_0,
+  MROM: {
+    name: SOC.IO.MROM,
     start: 0x00001000,
     end:   0x00001fff,
     heterogeneous: true

--- a/soc_cfg/sel4_vcu118_cfg.yml
+++ b/soc_cfg/sel4_vcu118_cfg.yml
@@ -1,0 +1,120 @@
+SOC:
+  TEST: {
+    name: SOC.IO.TEST,
+    start: 0x50000000,
+    end:   0x5000000f,
+    heterogeneous: true
+    }
+  CLINT: {
+    name: SOC.IO.CLINT,
+    start: 0x10000000,
+    end:   0x1000ffff,
+    heterogeneous: true
+    }
+  PLIC: {
+    name: SOC.IO.PLIC,
+    start: 0x0c000000,
+    end:   0x0c3fffff,
+    heterogeneous: true
+    }
+  DRAM: {
+    name: SOC.Memory.DDR4_0,
+    start: 0xc0000000,
+    end:   0xffffffff,
+    tag_granularity: 4,
+    heterogeneous: true
+    }
+  RAM: {
+    name: SOC.Memory.Code_1,
+    start: 0x0c0008680,
+    end:   0x0c00094ff,
+    tag_granularity: 4,
+    heterogeneous: true
+    }
+  RAM: {
+    name: SOC.Memory.Code_2,
+    start: 0x0c0200000,
+    end:   0x0c0800097,
+    tag_granularity: 4,
+    heterogeneous: true
+    }
+  RAM: {
+    name: SOC.Memory.Code_3,
+    start: 0x0c4000000,
+    end:   0x0c43fffff,
+    tag_granularity: 4,
+    heterogeneous: true
+    }
+  RAM: {
+    name: SOC.Memory.Code_4,
+    start: 0x0d0000000,
+    end:   0x0dfffffff,
+    tag_granularity: 4,
+    heterogeneous: true
+    }
+  BOOTROM: {
+    name: SOC.Memory.BRAM_CTRL_0,
+    start: 0x70000000,
+    end:   0x70000fff,
+    heterogeneous: true
+  }
+  DMA: {
+    name: SOC.Memory.DMA_0,
+    start: 0x62200000,
+    end:   0x6220ffff,
+    heterogeneous: false
+  }
+  ETHERNET: {
+    name: SOC.IO.Ethernet_0,
+    start: 0x62100000,
+    end:   0x6213ffff,
+    heterogeneous: false
+  }
+  FLASH0: {
+    name: SOC.Memory.QSPI_0,
+    start: 0x40000000,
+    end:   0x4fffffff,
+    heterogeneous: false
+  }
+  FLASH1: {
+    name: SOC.Memory.QSPI_0,
+    start: 0x62400000,
+    end:   0x62400fff,
+    heterogeneous: false
+  }
+  SRESET: {
+    name: SOC.IO.GPIO_0,
+    start: 0x6fff0000,
+    end:   0x6fffffff,
+    heterogeneous: false
+    }
+  UART0: {
+    name: SOC.IO.UART_0,
+    start: 0x62300000,
+    end:   0x62300fff,
+    heterogeneous: false
+    }
+  UART1: {
+    name: SOC.IO.UART_1,
+    start: 0x62340000,
+    end:   0x62340fff,
+    heterogeneous: false
+    }
+  I2C0: {
+    name: SOC.IO.I2C_0,
+    start: 0x62310000,
+    end:   0x62310fff,
+    heterogeneous: false
+    }
+  SPI: {
+    name: SOC.Memory.QSPI_1,
+    start: 0x62320000,
+    end:   0x62320fff,
+    heterogeneous: false
+    }
+  GPIO1: {
+    name: SOC.IO.GPIO_1,
+    start: 0x62330000,
+    end:   0x62330fff,
+    heterogeneous: false
+    }

--- a/tagging_tools/tag_file.h
+++ b/tagging_tools/tag_file.h
@@ -44,7 +44,7 @@ bool save_tag_indexes(std::vector<const metadata_t *> &metadata_values,
                       int32_t register_default, int32_t csr_default,
                       std::string file_name);
 bool write_headers(std::list<range_t> &code_ranges,
-                   std::list<range_t> &data_ranges,
+                   std::list<std::pair<range_t, uint8_t>> &data_ranges,
                    bool is_64_bit, std::string tag_filename);
 bool load_firmware_tag_file(std::list<range_t> &code_ranges,
                             std::list<range_t> &data_ranges,

--- a/validator/include/platform_types.h
+++ b/validator/include/platform_types.h
@@ -47,6 +47,7 @@ typedef uint64_t reg_t;
 #define PRIreg  "lx"
 
 #define READER_MASK 0xFFFFFFFFFFFFFFFFull
+#define PLATFORM_WORD_SIZE 8
 #else
 typedef uint32_t address_t;
 typedef uint32_t reg_t;
@@ -56,10 +57,11 @@ typedef uint32_t reg_t;
 #define PRIreg  "x"
 
 #define READER_MASK 0x00000000FFFFFFFFull
+#define PLATFORM_WORD_SIZE 4
 #endif
 typedef uint32_t insn_bits_t;
 
-#define PLATFORM_WORD_SIZE 4
+#define MIN_TAG_GRANULARITY 4
 
 }
 

--- a/validator/include/soc_tag_configuration.h
+++ b/validator/include/soc_tag_configuration.h
@@ -43,6 +43,7 @@ class soc_tag_configuration_t {
     address_t start;
     address_t end;
     bool heterogeneous;
+    size_t tag_granularity = 32;
     meta_set_t const *meta_set;
   };
 

--- a/validator/include/soc_tag_configuration.h
+++ b/validator/include/soc_tag_configuration.h
@@ -43,7 +43,8 @@ class soc_tag_configuration_t {
     address_t start;
     address_t end;
     bool heterogeneous;
-    size_t tag_granularity = 32;
+    size_t tag_granularity = 4;
+    size_t word_size = 4;
     meta_set_t const *meta_set;
   };
 

--- a/validator/include/tag_utils.h
+++ b/validator/include/tag_utils.h
@@ -95,39 +95,37 @@ class platform_ram_tag_provider_t : public tag_provider_t {
 
   public:
   platform_ram_tag_provider_t(address_t size, tag_t tag, size_t word_size, size_t tag_granularity) :
-  size(size), word_size(word_size), tags(size / 4, tag), tag_granularity(tag_granularity) {  }
+  size(size), word_size(word_size), tags((size / MIN_TAG_GRANULARITY)+1, tag), tag_granularity(tag_granularity) {  }
 
   bool get_insn_tag(address_t addr, tag_t &t) {
     if (addr < size) {
-      t = tags[addr / 4];
+      t = tags[addr / MIN_TAG_GRANULARITY];
       return true;
     }
     return false;
   }
 
   bool get_tag(address_t addr, tag_t &t) {
-      if (addr < size) {
-          if(tag_granularity == 4)
-              t = tags[addr / 4];
-          else if(tag_granularity == 8)
-              t = tags[(addr / 8*2)];
+    if (addr < size) {
+      addr  &= -tag_granularity;
+      t = tags[addr / MIN_TAG_GRANULARITY];
       return true;
     }
     return false;
   }
+
   bool set_insn_tag(address_t addr, tag_t t) {
     if (addr < size) {
-      tags[addr / 4] = t;
+      tags[addr / MIN_TAG_GRANULARITY] = t;
       return true;
     }
     return false;
   }
+
   bool set_tag(address_t addr, tag_t t) {
     if (addr < size) {
-          if(tag_granularity == 4)
-              tags[addr / 4] = t;
-          else if(tag_granularity == 8)
-              tags[(addr / 8)*2] = t;
+      addr  &= -tag_granularity;
+      tags[addr / MIN_TAG_GRANULARITY] = t;
       return true;
     }
     return false;

--- a/validator/include/tag_utils.h
+++ b/validator/include/tag_utils.h
@@ -48,18 +48,24 @@ typedef uintptr_t tag_t;
 
 struct tag_provider_t {
   virtual ~tag_provider_t() { }
+  virtual bool get_insn_tag(address_t addr, tag_t &tag) = 0;
   virtual bool get_tag(address_t addr, tag_t &tag) = 0;
   virtual bool set_tag(address_t addr, tag_t tag) = 0;
+  virtual bool set_insn_tag(address_t addr, tag_t tag) = 0;
 };
 
 class uniform_tag_provider_t : public tag_provider_t {
   private:
-  size_t tag_granularity; // in bits
+  size_t tag_granularity; // number of bytes a tag applies to
   address_t size;
   tag_t tag;
 
   public:
   uniform_tag_provider_t(address_t size, tag_t tag, size_t tag_granularity) : size(size), tag(tag), tag_granularity(tag_granularity) { }
+  bool get_insn_tag(address_t addr, tag_t &t) {
+      return get_tag(addr, t);
+  }
+
   bool get_tag(address_t addr, tag_t &t) {
     if (addr < size) {
       t = tag;
@@ -68,6 +74,9 @@ class uniform_tag_provider_t : public tag_provider_t {
     return false;
   }
 
+  bool set_insn_tag(address_t addr, tag_t t) {
+      return set_tag(addr, t);
+  }
   bool set_tag(address_t addr, tag_t t) {
     if (addr < size) {
       tag = t;
@@ -80,23 +89,45 @@ class uniform_tag_provider_t : public tag_provider_t {
 class platform_ram_tag_provider_t : public tag_provider_t {
   private:
   address_t size;
-  size_t tag_granularity; // in bits
-  unsigned word_size; // number of bytes a tag applies to
+  size_t tag_granularity; // number of bytes a tag applies to
+  unsigned word_size;
   std::vector<tag_t> tags;
 
   public:
-  platform_ram_tag_provider_t(address_t size, tag_t tag, size_t tag_granularity) :
-  size(size), word_size(tag_granularity/8), tags(size / word_size, tag), tag_granularity(tag_granularity) {  }
-  bool get_tag(address_t addr, tag_t &t) {
+  platform_ram_tag_provider_t(address_t size, tag_t tag, size_t word_size, size_t tag_granularity) :
+  size(size), word_size(word_size), tags(size / 4, tag), tag_granularity(tag_granularity) {  }
+
+  bool get_insn_tag(address_t addr, tag_t &t) {
     if (addr < size) {
-      t = tags[addr / word_size];
+      t = tags[addr / 4];
+      return true;
+    }
+    return false;
+  }
+
+  bool get_tag(address_t addr, tag_t &t) {
+      if (addr < size) {
+          if(tag_granularity == 4)
+              t = tags[addr / 4];
+          else if(tag_granularity == 8)
+              t = tags[(addr / 8*2)];
+      return true;
+    }
+    return false;
+  }
+  bool set_insn_tag(address_t addr, tag_t t) {
+    if (addr < size) {
+      tags[addr / 4] = t;
       return true;
     }
     return false;
   }
   bool set_tag(address_t addr, tag_t t) {
     if (addr < size) {
-      tags[addr / word_size] = t;
+          if(tag_granularity == 4)
+              tags[addr / 4] = t;
+          else if(tag_granularity == 8)
+              tags[(addr / 8)*2] = t;
       return true;
     }
     return false;
@@ -129,12 +160,30 @@ class tag_bus_t {
   void add_provider(address_t start_addr, address_t end_addr, tag_provider_t *provider) {
     provider_map.add_provider(start_addr, end_addr, provider);
   }
+
+  bool load_insn_tag(address_t addr, tag_t &tag) {
+    tag_provider_t *tp;
+    address_t offset;
+    tp = provider_map.get_provider(addr, offset);
+    if (tp)
+      return tp->get_insn_tag(offset, tag);
+    return false;
+  }
+
   bool load_tag(address_t addr, tag_t &tag) {
     tag_provider_t *tp;
     address_t offset;
     tp = provider_map.get_provider(addr, offset);
     if (tp)
       return tp->get_tag(offset, tag);
+    return false;
+  }
+  bool store_insn_tag(address_t addr, tag_t tag) {
+    tag_provider_t *tp;
+    address_t offset;
+    tp = provider_map.get_provider(addr, offset);
+    if (tp)
+      return tp->set_insn_tag(offset, tag);
     return false;
   }
   bool store_tag(address_t addr, tag_t tag) {

--- a/validator/include/tag_utils.h
+++ b/validator/include/tag_utils.h
@@ -54,11 +54,12 @@ struct tag_provider_t {
 
 class uniform_tag_provider_t : public tag_provider_t {
   private:
+  size_t tag_granularity; // in bits
   address_t size;
   tag_t tag;
 
   public:
-  uniform_tag_provider_t(address_t size, tag_t tag) : size(size), tag(tag) { }
+  uniform_tag_provider_t(address_t size, tag_t tag, size_t tag_granularity) : size(size), tag(tag), tag_granularity(tag_granularity) { }
   bool get_tag(address_t addr, tag_t &t) {
     if (addr < size) {
       t = tag;
@@ -79,12 +80,13 @@ class uniform_tag_provider_t : public tag_provider_t {
 class platform_ram_tag_provider_t : public tag_provider_t {
   private:
   address_t size;
-  unsigned word_size;
+  size_t tag_granularity; // in bits
+  unsigned word_size; // number of bytes a tag applies to
   std::vector<tag_t> tags;
 
   public:
-  platform_ram_tag_provider_t(address_t size, unsigned word_size, tag_t tag) :
-  size(size), word_size(word_size), tags(size / word_size, tag) {  }
+  platform_ram_tag_provider_t(address_t size, tag_t tag, size_t tag_granularity) :
+  size(size), word_size(tag_granularity/8), tags(size / word_size, tag), tag_granularity(tag_granularity) {  }
   bool get_tag(address_t addr, tag_t &t) {
     if (addr < size) {
       t = tags[addr / word_size];

--- a/validator/riscv/rv32_validator.cc
+++ b/validator/riscv/rv32_validator.cc
@@ -68,7 +68,7 @@ void rv32_validator_base_t::apply_metadata(metadata_memory_map_t *md_map) {
     for (address_t start = e.first.start; start < e.first.end; start += 4) {
 //      std::string s = render_metadata(e.second);
 //      printf("0x%08x: %s\n", start, s.c_str());
-      if (!tag_bus.store_tag(start, m_to_t(ms_cache->canonize(e.second)))) {
+      if (!tag_bus.store_insn_tag(start, m_to_t(ms_cache->canonize(e.second)))) {
 	throw configuration_exception_t("unable to apply metadata");
       }
     }
@@ -375,7 +375,7 @@ void rv32_validator_t::prepare_eval(address_t pc, insn_bits_t insn) {
     }
   }
 
-  if (!tag_bus.load_tag(pc_paddr, ci_tag)) {
+  if (!tag_bus.load_insn_tag(pc_paddr, ci_tag)) {
     printf("failed to load CI tag for PC 0x%" PRIaddr " (0x%" PRIaddr ")\n", pc, pc_paddr);
   }
 //    printf("ci_tag: 0x%" PRIaddr "\n", ci_tag);

--- a/validator/riscv/rv32_validator.cc
+++ b/validator/riscv/rv32_validator.cc
@@ -356,7 +356,6 @@ void rv32_validator_t::prepare_eval(address_t pc, insn_bits_t insn) {
         mem_addr += imm;
 
       /* mask off unaligned bits, just in case */
-      mem_addr &= ~((address_t)(sizeof(address_t) - 1));
     }
     mem_paddr = addr_fixer(mem_addr);
     ctx->bad_addr = mem_addr;

--- a/validator/src/soc_tag_configuration.cc
+++ b/validator/src/soc_tag_configuration.cc
@@ -61,16 +61,11 @@ void soc_tag_configuration_t::process_element(std::string element_name, const YA
   }
   
   if (n["tag_granularity"]) {
-    elt.tag_granularity = n["tag_granularity"].as<unsigned long>();
+    elt.tag_granularity = n["tag_granularity"].as<size_t>();
   } else {
-#ifdef RV64_VALIDATOR
-    elt.tag_granularity = 8;
-    elt.word_size = 8;
-#else
-    elt.tag_granularity = 4;
-    elt.word_size = 4;
-#endif
+    elt.tag_granularity = sizeof(address_t);
   }
+  elt.word_size = sizeof(address_t);
 
   if (n["start"]) {
     elt.start = n["start"].as<address_t>();

--- a/validator/src/soc_tag_configuration.cc
+++ b/validator/src/soc_tag_configuration.cc
@@ -60,6 +60,16 @@ void soc_tag_configuration_t::process_element(std::string element_name, const YA
     throw configuration_exception_t("'name' field not present for element " + element_name);
   }
   
+  if (n["tag_granularity"]) {
+    elt.tag_granularity = n["tag_granularity"].as<unsigned long>();
+  } else {
+#ifdef RV64_VALIDATOR
+    elt.tag_granularity = 64;
+#else
+    elt.tag_granularity = 32;
+#endif
+  }
+
   if (n["start"]) {
     elt.start = n["start"].as<address_t>();
   } else {
@@ -98,12 +108,12 @@ void soc_tag_configuration_t::apply(tag_bus_t *tag_bus, tag_converter_t *convert
   for (auto &e: elements) {
     if (e.heterogeneous) {
       tag_bus->add_provider(e.start, e.end,
-			    new platform_ram_tag_provider_t(e.end - e.start, 4,
-							    converter->m_to_t(e.meta_set)));
+			    new platform_ram_tag_provider_t(e.end - e.start, 
+							    converter->m_to_t(e.meta_set), e.tag_granularity));
     } else {
       tag_bus->add_provider(e.start, e.end,
 			    new uniform_tag_provider_t(e.end - e.start,
-						       converter->m_to_t(e.meta_set)));
+						       converter->m_to_t(e.meta_set), e.tag_granularity));
     }
   }
 }

--- a/validator/src/soc_tag_configuration.cc
+++ b/validator/src/soc_tag_configuration.cc
@@ -64,9 +64,11 @@ void soc_tag_configuration_t::process_element(std::string element_name, const YA
     elt.tag_granularity = n["tag_granularity"].as<unsigned long>();
   } else {
 #ifdef RV64_VALIDATOR
-    elt.tag_granularity = 64;
+    elt.tag_granularity = 8;
+    elt.word_size = 8;
 #else
-    elt.tag_granularity = 32;
+    elt.tag_granularity = 4;
+    elt.word_size = 4;
 #endif
   }
 
@@ -109,7 +111,7 @@ void soc_tag_configuration_t::apply(tag_bus_t *tag_bus, tag_converter_t *convert
     if (e.heterogeneous) {
       tag_bus->add_provider(e.start, e.end,
 			    new platform_ram_tag_provider_t(e.end - e.start, 
-							    converter->m_to_t(e.meta_set), e.tag_granularity));
+							    converter->m_to_t(e.meta_set), e.word_size, e.tag_granularity));
     } else {
       tag_bus->add_provider(e.start, e.end,
 			    new uniform_tag_provider_t(e.end - e.start,


### PR DESCRIPTION
The soc config files now have an optional `tag_granularity` field, which takes the tag granularity for that range in bytes. If not specified, the word size is assumed.

This is added to the data TMT information used to run on the FPGA.

As well, the qemu validator did not differentiate between data and instruction TMTs. This was simpler, but did not match the behavior on the FPGA. Instructions are now always checked at 32-bit granularity, regardless of the data granularity of the range.