### PR TITLE
Make some tagging tools failures non-fatal

### DIFF
--- a/tagging_tools/TagElfFile.py
+++ b/tagging_tools/TagElfFile.py
@@ -33,10 +33,10 @@ def generate_tag_array(elfname, range_file, policy_meta_info, rv64):
 
     presult = subprocess.call(base_command.split(' '))
 
-    if presult != 0:
-        sys.exit(presult)
-
     os.remove(tag_array_filename)
+
+    if presult != 0:
+        return presult
 
     start_addr = ""
     pout = subprocess.check_output([tool_prefix + 'objdump', '--target', bfd_target ,'-h', elfname])
@@ -55,3 +55,5 @@ def generate_tag_array(elfname, range_file, policy_meta_info, rv64):
             range_file.write_range(start_addr + (mid*bytes_per_address) + bytes_per_address,
                                    start_addr + (mid*bytes_per_address) + (2*bytes_per_address),
                                    m.get('name'))
+
+    return presult

--- a/tagging_tools/gen_tag_info
+++ b/tagging_tools/gen_tag_info
@@ -110,7 +110,10 @@ def main():
 
         if policy_inits['Require']:
             # save the inits stuff
-            TagElfFile.generate_tag_array(args.bin, range_file, policy_metas, args.arch == 'rv64');
+            rc = TagElfFile.generate_tag_array(args.bin, range_file, policy_metas, args.arch == 'rv64');
+            if not rc:
+                # We don't normally use this right now, so it's not fatal
+                print("Couldn't add .tag_array to binary")
         range_file.finish()
 
         if args.arch == 'rv64':
@@ -145,7 +148,8 @@ def main():
                                  args.entities)
         if presult != 0:
             print("md_embed failed")
-            sys.exit(presult)
+            # We don't normally use this right now, so it's not fatal
+#             sys.exit(presult)
 
 
         # generate the asm file


### PR DESCRIPTION
These changes only affect the parts of the tagging tools that embed tag info into the ELF.

These parts failing are changed to be non-fatal. When used more, the test infrastructure should be modified to not run gen_tag_info on the same ELF file in parallel.

The failure was also resulting in a temp file not getting cleaned up.