### PR TITLE
Fix the argument index for the -f option of dump_tags

### DIFF
--- a/tagging_tools/dump_tags.cc
+++ b/tagging_tools/dump_tags.cc
@@ -205,9 +205,11 @@ int main(int argc, char **argv) {
       case 'f':
         firmware = true;
 
-        entries_arg = optind + 1;
-        if(entries_arg < argc) {
-           num_entries = strtoul(argv[entries_arg], NULL, 0);
+        if(optind < argc) {
+           num_entries = strtoul(argv[optind], NULL, 0);
+        } else {
+          usage();
+          return 1;
         }
         break;
       case '?':


### PR DESCRIPTION
According to the getopt documentation, `optind` points to the argument of an option and not the option itself (i.e. passing `-f 0` into dump_tags will cause `optind` to point to `"0"` and not `"-f"`), so adding 1 to it is incorrect.