### PR TITLE
Fix some script bugs

### DIFF
--- a/tagging_tools/LLVMMetadataTagger.py
+++ b/tagging_tools/LLVMMetadataTagger.py
@@ -12,10 +12,10 @@ def bytes_to_uint(it, size):
     return int.from_bytes(data, byteorder='little', signed=False)
 
 def round_up(x, align):
-    return ~((~x) & ~align)
+    return -((-x) & -align)
 
 class LLVMMetadataTagger:
-    PTR_SIZE = 4
+    PTR_SIZE = 4 # For instructions, not data
 
     metadata_ops = {
         "DMD_SET_BASE_ADDRESS_OP": 0x01,

--- a/tagging_tools/gen_tag_info
+++ b/tagging_tools/gen_tag_info
@@ -111,7 +111,7 @@ def main():
         if policy_inits['Require']:
             # save the inits stuff
             rc = TagElfFile.generate_tag_array(args.bin, range_file, policy_metas, args.arch == 'rv64');
-            if not rc:
+            if rc:
                 # We don't normally use this right now, so it's not fatal
                 print("Couldn't add .tag_array to binary")
         range_file.finish()


### PR DESCRIPTION
This fixes the end of range calculation for code sections, which caused an error on FPGA runs. It showed up as this error `During metadata initialization, unable to locate tmt range for 0xc0031550.`, where the address was just past the end of the code.

This is the difference in calculation:
```
>>> align=4
>>> x = 0x20
>>> print("round up "+hex(x)+"\t  before: "+hex(~((~x) & ~align)) + " after: " + hex(-((-x) & -align)));
round up 0x20     before: 0x24 after: 0x20
>>> x = 0x21
>>> print("round up "+hex(x)+"\t  before: "+hex(~((~x) & ~align)) + " after: " + hex(-((-x) & -align)));
round up 0x21     before: 0x25 after: 0x24
```