### PR TITLE
Add entry for mailbox to VCU118 SOC cfg

### DIFF
--- a/soc_cfg/gfe-vcu118.yml
+++ b/soc_cfg/gfe-vcu118.yml
@@ -89,3 +89,9 @@ SOC:
     end:   0x62330fff,
     heterogeneous: false
     }
+  MAILBOX: {
+    name: SOC.MAILBOX,
+    start: 0x10000,
+    end: 0x100ff,
+    heterogeneous: false
+    }


### PR DESCRIPTION
Adds an entry into gfe-vcu118.yml for the PIPE mailbox starting at physical address `0x10000` and ending at `0x100ff` so that AP mailbox accesses can be tagged properly.