### PR TITLE
Switch Tags from Pointers to Indices

### DIFF
--- a/validator/include/policy-glue/policy_eval.h
+++ b/validator/include/policy-glue/policy_eval.h
@@ -70,12 +70,6 @@ int eval_policy(context_t* ctx, const operands_t* ops, results_t* res);
  */
 void complete_eval(context_t* ctx, const operands_t* ops, results_t* res);
 
-/**
- * Helper Fn to optomize by returning a cannonical representation of
- * a metadata set. Necessary for performance and to save memory.
- */  
-meta_set_t* canonize(meta_set_t* ts);
-
   
 /**
  * Print eval status

--- a/validator/include/policy-glue/policy_eval.h
+++ b/validator/include/policy-glue/policy_eval.h
@@ -53,7 +53,7 @@ void free_eval_params(context_t** ctx, operands_t** ops, results_t** res);
 /**
  * Initialize context and set up operands before policy eval.
  */
-void prepare_eval(context_t* ctx, operands_t* ops, results_t* res);
+void prepare_eval(context_t* ctx, const operands_t* ops, results_t* res);
 
 /**
  * Evaluate policy with context and operands, populate results.
@@ -63,12 +63,12 @@ void prepare_eval(context_t* ctx, operands_t* ops, results_t* res);
  *    policyImpFailure = -1
  *    policySuccess = 1
  */
-int eval_policy(context_t* ctx, operands_t* ops, results_t* res);
+int eval_policy(context_t* ctx, const operands_t* ops, results_t* res);
 
 /**
  * Install rule with operands and results.
  */
-void complete_eval(context_t* ctx, operands_t* ops, results_t* res);
+void complete_eval(context_t* ctx, const operands_t* ops, results_t* res);
 
 /**
  * Helper Fn to optomize by returning a cannonical representation of
@@ -100,7 +100,7 @@ void debug_results(const context_t* ctx, const results_t* res);
 /**
  * Call this if there is a rule violation
  */
-void handle_violation(context_t* ctx, operands_t* ops, results_t* out);
+void handle_violation(context_t* ctx, const operands_t* ops, results_t* out);
   
 /**
  * Call this if there is a fatal error in the eval code

--- a/validator/include/policy-glue/riscv_isa.h
+++ b/validator/include/policy-glue/riscv_isa.h
@@ -99,19 +99,24 @@ typedef struct context {
 /**
  * Structure that holds input operands for rule eval
  */  
-typedef struct operands {
+typedef struct operands_t {
   tag_t pc;
   tag_t ci;
   tag_t op1;
   tag_t op2;
   tag_t op3;
   tag_t mem;
+
+#ifdef __cplusplus
+  bool operator ==(const operands_t& that) const { return pc == that.pc && ci == that.ci && op1 == that.op1 && op2 == that.op2 && op3 == that.op3 && mem == that.mem; }
+  bool operator !=(const operands_t& that) const { return !(*this == that); }
+#endif
 } operands_t;
 
 /**
  * Structure that holds results after rule eval
  */  
-typedef struct results {
+typedef struct results_t {
   tag_t pc;
   tag_t rd;
   tag_t csr;
@@ -119,6 +124,12 @@ typedef struct results {
   bool pcResult;
   bool rdResult;
   bool csrResult;
+
+#ifdef __cplusplus
+  bool operator ==(const results_t& that) const { return pc == that.pc && rd == that.rd && csr == that.csr &&
+                                                         pcResult == that.pcResult && rdResult == that.rdResult && csrResult == that.csrResult; }
+  bool operator !=(const results_t& that) const { return !(*this == that); }
+#endif
 } results_t;
 
 #ifdef __cplusplus
@@ -130,9 +141,7 @@ namespace std
 
 template<>
 struct equal_to<policy_engine::operands_t> {
-  bool operator ()(const policy_engine::operands_t& a, const policy_engine::operands_t& b) const {
-    return (a.op1 == b.op1 && a.op2 == b.op2 && a.op3 == b.op3 && a.mem == b.mem && a.pc == b.pc && a.ci == b.ci);
-  }
+  bool operator ()(const policy_engine::operands_t& a, const policy_engine::operands_t& b) const { return a == b; }
 };
 
 template<>

--- a/validator/include/policy-glue/riscv_isa.h
+++ b/validator/include/policy-glue/riscv_isa.h
@@ -112,9 +112,9 @@ typedef struct operands {
  * Structure that holds results after rule eval
  */  
 typedef struct results {
-  meta_set_t* pc;
-  meta_set_t* rd;
-  meta_set_t* csr;
+  const meta_set_t* pc;
+  const meta_set_t* rd;
+  const meta_set_t* csr;
   // flags indicate results are present
   bool pcResult;
   bool rdResult;

--- a/validator/include/policy-glue/riscv_isa.h
+++ b/validator/include/policy-glue/riscv_isa.h
@@ -100,21 +100,21 @@ typedef struct context {
  * Structure that holds input operands for rule eval
  */  
 typedef struct operands {
-  const meta_set_t* pc;
-  const meta_set_t* ci;
-  const meta_set_t* op1;
-  const meta_set_t* op2;
-  const meta_set_t* op3;
-  const meta_set_t* mem;
+  tag_t pc;
+  tag_t ci;
+  tag_t op1;
+  tag_t op2;
+  tag_t op3;
+  tag_t mem;
 } operands_t;
 
 /**
  * Structure that holds results after rule eval
  */  
 typedef struct results {
-  const meta_set_t* pc;
-  const meta_set_t* rd;
-  const meta_set_t* csr;
+  tag_t pc;
+  tag_t rd;
+  tag_t csr;
   // flags indicate results are present
   bool pcResult;
   bool rdResult;
@@ -124,6 +124,34 @@ typedef struct results {
 #ifdef __cplusplus
 } // extern "C"
 } // namespace policy_engine
+
+namespace std
+{
+
+template<>
+struct equal_to<policy_engine::operands_t> {
+  bool operator ()(const policy_engine::operands_t& a, const policy_engine::operands_t& b) const {
+    return (a.op1 == b.op1 && a.op2 == b.op2 && a.op3 == b.op3 && a.mem == b.mem && a.pc == b.pc && a.ci == b.ci);
+  }
+};
+
+template<>
+struct hash<policy_engine::operands_t> {
+  size_t operator ()(const policy_engine::operands_t& ops) const {
+    // XOR all meta_set_t pointers (operands) together.
+    // Shift pointers slightly so that two identical
+    // tags don't cancel out to 0.
+    size_t hash = ops.pc;
+    hash ^= ops.ci  << 1;
+    hash ^= ops.op1 << 2;
+    hash ^= ops.op2 << 3;
+    hash ^= ops.op3 << 4;
+    hash ^= ops.mem << 5;
+    return hash;
+  }
+};
+
+} // namespace std
 #endif
 
 #endif // RISCV_ISA_H

--- a/validator/include/policy-glue/tag_types.h
+++ b/validator/include/policy-glue/tag_types.h
@@ -30,12 +30,14 @@
 #include <stdint.h>
 
 // create a shared types file for pex and kernel
-  /**
-     This type is used primarily to identify where we store specific tagged values that we use to paint
-     things with in the kernel.  The concept is to keep the locations in the code where we hold these
-     values clear.  The uses should be quite rare.
-   */
-  typedef uintptr_t tagged_value_t;
+/**
+    This type is used primarily to identify where we store specific tagged values that we use to paint
+    things with in the kernel.  The concept is to keep the locations in the code where we hold these
+    values clear.  The uses should be quite rare.
+  */
+typedef uintptr_t tagged_value_t;
+typedef intptr_t tag_t;
+#define BAD_TAG_VALUE ((tag_t)-1)
 
 
 #endif

--- a/validator/include/soc_tag_configuration.h
+++ b/validator/include/soc_tag_configuration.h
@@ -45,7 +45,7 @@ public:
     bool heterogeneous;
     size_t tag_granularity = 4;
     size_t word_size = 4;
-    const meta_set_t* meta_set;
+    tag_t tag;
   };
 
 private:

--- a/validator/include/soc_tag_configuration.h
+++ b/validator/include/soc_tag_configuration.h
@@ -45,11 +45,8 @@ public:
     bool heterogeneous;
     size_t tag_granularity = 4;
     size_t word_size = 4;
-    meta_set_t* meta_set;
+    const meta_set_t* meta_set;
   };
-
-  using iterator = std::list<soc_element_t>::iterator;
-  using const_iterator = std::list<soc_element_t>::const_iterator;
 
 private:
   std::list<soc_element_t> elements;
@@ -58,6 +55,9 @@ private:
   void process_element(const std::string& element_name, const YAML::Node& n, int xlen);
 
 public:
+  using iterator = typename decltype(elements)::iterator;
+  using const_iterator = typename decltype(elements)::const_iterator;
+
   soc_tag_configuration_t(meta_set_factory_t* factory, const std::string& file_name, int xlen);
 
   void apply(tag_bus_t* tag_bus, meta_set_cache_t* ms_cache);

--- a/validator/include/tag_based_validator.h
+++ b/validator/include/tag_based_validator.h
@@ -50,7 +50,7 @@ public:
 
   // Provides the tag for a given address.  Used for debugging.
   virtual tag_t& get_tag(address_t addr) = 0;
-  virtual meta_set_t* get_meta_set(address_t addr) = 0;
+  virtual const meta_set_t* get_meta_set(address_t addr) = 0;
 };
 
 } // namespace policy_engine

--- a/validator/include/tag_based_validator.h
+++ b/validator/include/tag_based_validator.h
@@ -49,7 +49,7 @@ public:
 
   // Provides the tag for a given address.  Used for debugging.
   virtual tag_t& get_tag(address_t addr) = 0;
-  virtual const meta_set_t* get_meta_set(address_t addr) = 0;
+  virtual const meta_set_t& get_meta_set(address_t addr) = 0;
 };
 
 } // namespace policy_engine

--- a/validator/include/tag_based_validator.h
+++ b/validator/include/tag_based_validator.h
@@ -37,11 +37,10 @@
 namespace policy_engine {
 
 class tag_based_validator_t : public abstract_validator_t {
-protected:
+public:
   meta_set_cache_t ms_cache;
   meta_set_factory_t ms_factory;
-  
-public:
+
   tag_based_validator_t(const std::string& policy_dir) : ms_factory(meta_set_factory_t(&ms_cache, policy_dir)) {}
   virtual ~tag_based_validator_t() {}
 

--- a/validator/include/tag_utils.h
+++ b/validator/include/tag_utils.h
@@ -46,8 +46,7 @@ namespace policy_engine {
  * particular platform, in which case, there would be some conversion to policy data structures
  * required.
  */
-using tag_t = uintptr_t;
-#define PRItag PRIuPTR
+#define PRItag PRIdPTR
 
 static const tag_t BAD_TAG_VALUE = -1;
 

--- a/validator/include/tag_utils.h
+++ b/validator/include/tag_utils.h
@@ -46,7 +46,7 @@ namespace policy_engine {
  * particular platform, in which case, there would be some conversion to policy data structures
  * required.
  */
-typedef uintptr_t tag_t;
+using tag_t = uintptr_t;
 #define PRItag PRIuPTR
 
 static const tag_t BAD_TAG_VALUE = -1;

--- a/validator/include/tag_utils.h
+++ b/validator/include/tag_utils.h
@@ -48,8 +48,6 @@ namespace policy_engine {
  */
 #define PRItag PRIdPTR
 
-static const tag_t BAD_TAG_VALUE = -1;
-
 struct tag_provider_t {
   virtual ~tag_provider_t() {}
 

--- a/validator/riscv/debug.cc
+++ b/validator/riscv/debug.cc
@@ -69,12 +69,12 @@ void debug_status(const context_t *ctx, int status) {
 }
 
 void debug_operands(const context_t* ctx, const operands_t* ops) {
-  std::printf("    pc = "); dump_tag(ops->pc); std::printf("\n");
-  std::printf("    ci = "); dump_tag(ops->ci); std::printf("\n");
-  std::printf("    op1 = "); dump_tag(ops->op1); std::printf("\n");
-  std::printf("    op2 = "); dump_tag(ops->op2); std::printf("\n");
-  std::printf("    op3 = "); dump_tag(ops->op3); std::printf("\n");
-  std::printf("    mem = "); dump_tag(ops->mem); std::printf("\n");
+  std::printf("    pc = (%ld) ", ops->pc); dump_tag(ops->pc); std::printf("\n");
+  std::printf("    ci = (%ld) ", ops->ci); dump_tag(ops->ci); std::printf("\n");
+  std::printf("    op1 = (%ld) ", ops->op1); dump_tag(ops->op1); std::printf("\n");
+  std::printf("    op2 = (%ld) ", ops->op2); dump_tag(ops->op2); std::printf("\n");
+  std::printf("    op3 = (%ld) ", ops->op3); dump_tag(ops->op3); std::printf("\n");
+  std::printf("    mem = (%ld) ", ops->mem); dump_tag(ops->mem); std::printf("\n");
 }
 
 void debug_results(const context_t* ctx, const results_t* res) {

--- a/validator/riscv/debug.cc
+++ b/validator/riscv/debug.cc
@@ -28,6 +28,7 @@
 #include <cstdio>
 #include "policy_eval.h"
 #include "policy_utils.h"
+#include "tag_types.h"
 #include "tag_utils.h"
 #include "riscv_isa.h"
 

--- a/validator/riscv/debug.cc
+++ b/validator/riscv/debug.cc
@@ -28,17 +28,18 @@
 #include <cstdio>
 #include "policy_eval.h"
 #include "policy_utils.h"
+#include "tag_utils.h"
 #include "riscv_isa.h"
 
 namespace policy_engine {
 
-void dump_tag(const meta_set_t* ms) {
-  char tag_name[1024];
-  if (ms) {
-    meta_set_to_string(ms, tag_name, sizeof(tag_name));
-    std::printf("%s", tag_name);
+void dump_tag(tag_t tag) {
+  if (tag != BAD_TAG_VALUE) {
+    char tag_name[1024];
+    meta_set_to_string(get_ms(tag), tag_name, sizeof(tag_name));
+    std::printf(tag_name);
   } else {
-    std::printf("<null>");
+    std::printf("<invalid>");
   }
 }
 
@@ -76,7 +77,7 @@ void debug_operands(const context_t* ctx, const operands_t* ops) {
   std::printf("    mem = "); dump_tag(ops->mem); std::printf("\n");
 }
 
-void debug_results(const context_t *ctx, const results_t *res) {
+void debug_results(const context_t* ctx, const results_t* res) {
   if (res->pcResult) {
     std::printf("      pc = "); dump_tag(res->pc); std::printf("\n");
   }

--- a/validator/riscv/main.cc
+++ b/validator/riscv/main.cc
@@ -61,7 +61,7 @@ const tag_t canonize(const meta_set_t* ts) {
 }
 
 const meta_set_t* get_ms(tag_t tag) {
-  return rv_validator->ms_cache[tag];
+  return &rv_validator->ms_cache[tag];
 }
 
 void e_v_set_callbacks(RegisterReader_t reg_reader, MemoryReader_t mem_reader, AddressFixer_t addr_fixer) {
@@ -184,36 +184,32 @@ void e_v_rule_cache_stats() {
 }
 
 void e_v_pc_tag(char* dest, int n) {
-  meta_set_to_string(rv_validator->get_pc_meta_set(), dest, n);
+  meta_set_to_string(&rv_validator->get_pc_meta_set(), dest, n);
 }
 
 void e_v_csr_tag(char* dest, int n, uint64_t addr) {
   if (addr < 0x1000) {
-    meta_set_to_string(rv_validator->get_csr_meta_set(addr), dest, n);
+    meta_set_to_string(&rv_validator->get_csr_meta_set(addr), dest, n);
   } else
     std::strncpy(dest, "Out of range", n);
 }
 
 void e_v_reg_tag(char* dest, int n, uint64_t addr) {
   if (addr < 32) {
-    meta_set_to_string(rv_validator->get_ireg_meta_set(addr), dest, n);
+    meta_set_to_string(&rv_validator->get_ireg_meta_set(addr), dest, n);
   } else
     std::strncpy(dest, "Out of range", n);
 }
 
 void e_v_mem_tag(char* dest, int n, uint64_t addr) {
   if (addr <= rv_validator->address_max()) {
-    if (const meta_set_t* ms = rv_validator->get_meta_set(static_cast<address_t>(addr))) {
-      meta_set_to_string(ms, dest, n);
-    } else {
-      std::snprintf(dest, n, "Bad Address: %lx\n", addr);
-    }
+    meta_set_to_string(&rv_validator->get_meta_set(static_cast<address_t>(addr)), dest, n);
   } else
     std::strncpy(dest, "Out of range", n);
 }
 
 const char* eval_status(int status) {
-  switch(status) {
+  switch (status) {
     case policy_engine::POLICY_ERROR_FAILURE: return "Internal Policy Error";
     case policy_engine::POLICY_EXP_FAILURE:   return "Explicit Failure";
     case policy_engine::POLICY_IMP_FAILURE:   return "Implicit Failure";
@@ -239,17 +235,17 @@ void e_v_violation_msg(char* dest, int n) {
     }
     
     msg = msg + "\nMetadata:\n";
-    meta_set_to_string(rv_validator->failed_ops.pc != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->failed_ops.pc] : nullptr, tmp, s);
+    meta_set_to_string(rv_validator->failed_ops.pc != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.pc] : nullptr, tmp, s);
     msg = msg + "    Env   : " + tmp + "\n";
-    meta_set_to_string(rv_validator->failed_ops.ci != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->failed_ops.ci] : nullptr, tmp, s);
+    meta_set_to_string(rv_validator->failed_ops.ci != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.ci] : nullptr, tmp, s);
     msg = msg + "    Code  : " + tmp + "\n";
-    meta_set_to_string(rv_validator->failed_ops.op1 != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->failed_ops.op1] : nullptr, tmp, s);
+    meta_set_to_string(rv_validator->failed_ops.op1 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.op1] : nullptr, tmp, s);
     msg = msg + "    Op1   : " + tmp + "\n";
-    meta_set_to_string(rv_validator->failed_ops.op2 != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->failed_ops.op2] : nullptr, tmp, s);
+    meta_set_to_string(rv_validator->failed_ops.op2 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.op2] : nullptr, tmp, s);
     msg = msg + "    Op2   : " + tmp + "\n";
-    meta_set_to_string(rv_validator->failed_ops.op3 != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->failed_ops.op3] : nullptr, tmp, s);
+    meta_set_to_string(rv_validator->failed_ops.op3 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.op3] : nullptr, tmp, s);
     msg = msg + "    Op3   : " + tmp + "\n";
-    meta_set_to_string(rv_validator->failed_ops.mem != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->failed_ops.mem] : nullptr, tmp, s);
+    meta_set_to_string(rv_validator->failed_ops.mem != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.mem] : nullptr, tmp, s);
     msg = msg + "    Mem   : " + tmp + "\n";
     msg = msg + eval_status(rv_validator->ctx.policy_result) + "\n";
 
@@ -268,11 +264,11 @@ void e_v_meta_log_short(char* dest, int n) {
   char tmp[s];
   std::string msg;
 
-  meta_set_to_string(rv_validator->ops.ci != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->ops.ci] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.ci != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.ci] : nullptr, tmp, s);
   msg = msg + "C " + tmp;
-  meta_set_to_string(rv_validator->ops.pc != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->ops.pc] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.pc != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.pc] : nullptr, tmp, s);
   msg = msg + " E " + tmp;
-  meta_set_to_string(rv_validator->res.pc != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->res.pc] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->res.pc != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->res.pc] : nullptr, tmp, s);
   msg = msg + " -> E " + tmp;
   
   std::strncpy(dest, msg.c_str(), n);
@@ -283,28 +279,28 @@ void e_v_rule_eval_log(char* dest, int n) {
   char tmp[s];
   std::string msg = "\nMetadata:\n";
 
-  meta_set_to_string(rv_validator->ops.pc != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->ops.pc] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.pc != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.pc] : nullptr, tmp, s);
   msg = msg + "    Env   : " + tmp + "\n";
-  meta_set_to_string(rv_validator->ops.ci != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->ops.ci] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.ci != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.ci] : nullptr, tmp, s);
   msg = msg + "    Code  : " + tmp + "\n";
-  meta_set_to_string(rv_validator->ops.op1 != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->ops.op1] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.op1 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.op1] : nullptr, tmp, s);
   msg = msg + "    Op1   : " + tmp + "\n";
-  meta_set_to_string(rv_validator->ops.op2 != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->ops.op2] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.op2 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.op2] : nullptr, tmp, s);
   msg = msg + "    Op2   : " + tmp + "\n";
-  meta_set_to_string(rv_validator->ops.op3 != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->ops.op3] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.op3 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.op3] : nullptr, tmp, s);
   msg = msg + "    Op3   : " + tmp + "\n";
-  meta_set_to_string(rv_validator->ops.mem != policy_engine::BAD_TAG_VALUE ? rv_validator->ms_cache[rv_validator->ops.mem] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.mem != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.mem] : nullptr, tmp, s);
   msg = msg + "    Mem   : " + tmp + "\n";
 
   msg = msg + "\nResults:\n";
-  meta_set_to_string(rv_validator->ms_cache[rv_validator->res.pc], tmp, s);
+  meta_set_to_string(&rv_validator->ms_cache[rv_validator->res.pc], tmp, s);
   msg = msg + "    Env   : " + tmp + "\n";
   if (rv_validator->res.rdResult){
-    meta_set_to_string(rv_validator->ms_cache[rv_validator->res.rd], tmp, s);
+    meta_set_to_string(&rv_validator->ms_cache[rv_validator->res.rd], tmp, s);
     msg = msg + "    RD    : " + tmp + "\n";
   }
   if (rv_validator->res.csrResult){
-    meta_set_to_string(rv_validator->ms_cache[rv_validator->res.csr], tmp, s);
+    meta_set_to_string(&rv_validator->ms_cache[rv_validator->res.csr], tmp, s);
     msg = msg + "    CSR   : " + tmp + "\n";
   }
   

--- a/validator/riscv/main.cc
+++ b/validator/riscv/main.cc
@@ -62,7 +62,10 @@ tag_t canonize(const meta_set_t* ts) {
 }
 
 const meta_set_t* get_ms(tag_t tag) {
-  return &rv_validator->ms_cache[tag];
+  if (tag != policy_engine::BAD_TAG_VALUE)
+    return &rv_validator->ms_cache[tag];
+  else
+    return nullptr;
 }
 
 void e_v_set_callbacks(RegisterReader_t reg_reader, MemoryReader_t mem_reader, AddressFixer_t addr_fixer) {

--- a/validator/riscv/main.cc
+++ b/validator/riscv/main.cc
@@ -30,6 +30,7 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <string>
 #include <yaml-cpp/yaml.h>
 #include "meta_cache.h"
 #include "metadata_memory_map.h"
@@ -236,17 +237,17 @@ void e_v_violation_msg(char* dest, int n) {
     
     msg = msg + "\nMetadata:\n";
     meta_set_to_string(rv_validator->failed_ops.pc != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.pc] : nullptr, tmp, s);
-    msg = msg + "    Env   : " + tmp + "\n";
+    msg = msg + "    Env   : (" + std::to_string(rv_validator->failed_ops.pc) + ") " + tmp + "\n";
     meta_set_to_string(rv_validator->failed_ops.ci != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.ci] : nullptr, tmp, s);
-    msg = msg + "    Code  : " + tmp + "\n";
+    msg = msg + "    Code  : (" + std::to_string(rv_validator->failed_ops.ci) + ") " + tmp + "\n";
     meta_set_to_string(rv_validator->failed_ops.op1 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.op1] : nullptr, tmp, s);
-    msg = msg + "    Op1   : " + tmp + "\n";
+    msg = msg + "    Op1   : (" + std::to_string(rv_validator->failed_ops.op1) + ") " + tmp + "\n";
     meta_set_to_string(rv_validator->failed_ops.op2 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.op2] : nullptr, tmp, s);
-    msg = msg + "    Op2   : " + tmp + "\n";
+    msg = msg + "    Op2   : (" + std::to_string(rv_validator->failed_ops.op2) + ") " + tmp + "\n";
     meta_set_to_string(rv_validator->failed_ops.op3 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.op3] : nullptr, tmp, s);
-    msg = msg + "    Op3   : " + tmp + "\n";
+    msg = msg + "    Op3   : (" + std::to_string(rv_validator->failed_ops.op3) + ") " + tmp + "\n";
     meta_set_to_string(rv_validator->failed_ops.mem != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.mem] : nullptr, tmp, s);
-    msg = msg + "    Mem   : " + tmp + "\n";
+    msg = msg + "    Mem   : (" + std::to_string(rv_validator->failed_ops.mem) + ") " + tmp + "\n";
     msg = msg + eval_status(rv_validator->ctx.policy_result) + "\n";
 
     if(rv_validator->failed_ctx.fail_msg)

--- a/validator/riscv/main.cc
+++ b/validator/riscv/main.cc
@@ -24,21 +24,22 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <cinttypes>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <yaml-cpp/yaml.h>
 #include "meta_cache.h"
-#include "meta_set_factory.h"
-#include "rv_validator.h"
 #include "metadata_memory_map.h"
+#include "meta_set_factory.h"
+#include "platform_types.h"
+#include "policy_meta_set.h"
+#include "policy_utils.h"
+#include "rv_validator.h"
 #include "tag_file.h"
 #include "validator_exception.h"
-#include "policy_utils.h"
-#include "platform_types.h"
-#include <yaml-cpp/yaml.h>
-#include <cinttypes>
 
 static std::unique_ptr<policy_engine::rv_validator_t> rv_validator = nullptr;
 static std::string policy_dir;
@@ -50,6 +51,13 @@ static int rule_cache_capacity;
 static bool DOA = false;
 
 extern "C" {
+
+const meta_set_t* canonize(const meta_set_t* ts) {
+  if (rv_validator)
+    return &rv_validator->ms_cache.canonize(*ts);
+  else
+    return nullptr;
+}
 
 void e_v_set_callbacks(RegisterReader_t reg_reader, MemoryReader_t mem_reader, AddressFixer_t addr_fixer) {
   if (!DOA) {

--- a/validator/riscv/main.cc
+++ b/validator/riscv/main.cc
@@ -54,7 +54,7 @@ static bool DOA = false;
 
 extern "C" {
 
-const tag_t canonize(const meta_set_t* ts) {
+tag_t canonize(const meta_set_t* ts) {
   if (rv_validator)
     return rv_validator->ms_cache.canonize(*ts);
   else

--- a/validator/riscv/main.cc
+++ b/validator/riscv/main.cc
@@ -58,11 +58,11 @@ tag_t canonize(const meta_set_t* ts) {
   if (rv_validator)
     return rv_validator->ms_cache.canonize(*ts);
   else
-    return policy_engine::BAD_TAG_VALUE;
+    return BAD_TAG_VALUE;
 }
 
 const meta_set_t* get_ms(tag_t tag) {
-  if (tag != policy_engine::BAD_TAG_VALUE)
+  if (tag != BAD_TAG_VALUE)
     return &rv_validator->ms_cache[tag];
   else
     return nullptr;
@@ -239,17 +239,17 @@ void e_v_violation_msg(char* dest, int n) {
     }
     
     msg = msg + "\nMetadata:\n";
-    meta_set_to_string(rv_validator->failed_ops.pc != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.pc] : nullptr, tmp, s);
+    meta_set_to_string(rv_validator->failed_ops.pc != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.pc] : nullptr, tmp, s);
     msg = msg + "    Env   : (" + std::to_string(rv_validator->failed_ops.pc) + ") " + tmp + "\n";
-    meta_set_to_string(rv_validator->failed_ops.ci != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.ci] : nullptr, tmp, s);
+    meta_set_to_string(rv_validator->failed_ops.ci != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.ci] : nullptr, tmp, s);
     msg = msg + "    Code  : (" + std::to_string(rv_validator->failed_ops.ci) + ") " + tmp + "\n";
-    meta_set_to_string(rv_validator->failed_ops.op1 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.op1] : nullptr, tmp, s);
+    meta_set_to_string(rv_validator->failed_ops.op1 != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.op1] : nullptr, tmp, s);
     msg = msg + "    Op1   : (" + std::to_string(rv_validator->failed_ops.op1) + ") " + tmp + "\n";
-    meta_set_to_string(rv_validator->failed_ops.op2 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.op2] : nullptr, tmp, s);
+    meta_set_to_string(rv_validator->failed_ops.op2 != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.op2] : nullptr, tmp, s);
     msg = msg + "    Op2   : (" + std::to_string(rv_validator->failed_ops.op2) + ") " + tmp + "\n";
-    meta_set_to_string(rv_validator->failed_ops.op3 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.op3] : nullptr, tmp, s);
+    meta_set_to_string(rv_validator->failed_ops.op3 != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.op3] : nullptr, tmp, s);
     msg = msg + "    Op3   : (" + std::to_string(rv_validator->failed_ops.op3) + ") " + tmp + "\n";
-    meta_set_to_string(rv_validator->failed_ops.mem != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.mem] : nullptr, tmp, s);
+    meta_set_to_string(rv_validator->failed_ops.mem != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->failed_ops.mem] : nullptr, tmp, s);
     msg = msg + "    Mem   : (" + std::to_string(rv_validator->failed_ops.mem) + ") " + tmp + "\n";
     msg = msg + eval_status(rv_validator->ctx.policy_result) + "\n";
 
@@ -268,11 +268,11 @@ void e_v_meta_log_short(char* dest, int n) {
   char tmp[s];
   std::string msg;
 
-  meta_set_to_string(rv_validator->ops.ci != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.ci] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.ci != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.ci] : nullptr, tmp, s);
   msg = msg + "C " + tmp;
-  meta_set_to_string(rv_validator->ops.pc != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.pc] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.pc != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.pc] : nullptr, tmp, s);
   msg = msg + " E " + tmp;
-  meta_set_to_string(rv_validator->res.pc != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->res.pc] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->res.pc != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->res.pc] : nullptr, tmp, s);
   msg = msg + " -> E " + tmp;
   
   std::strncpy(dest, msg.c_str(), n);
@@ -283,17 +283,17 @@ void e_v_rule_eval_log(char* dest, int n) {
   char tmp[s];
   std::string msg = "\nMetadata:\n";
 
-  meta_set_to_string(rv_validator->ops.pc != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.pc] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.pc != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.pc] : nullptr, tmp, s);
   msg = msg + "    Env   : " + tmp + "\n";
-  meta_set_to_string(rv_validator->ops.ci != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.ci] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.ci != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.ci] : nullptr, tmp, s);
   msg = msg + "    Code  : " + tmp + "\n";
-  meta_set_to_string(rv_validator->ops.op1 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.op1] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.op1 != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.op1] : nullptr, tmp, s);
   msg = msg + "    Op1   : " + tmp + "\n";
-  meta_set_to_string(rv_validator->ops.op2 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.op2] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.op2 != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.op2] : nullptr, tmp, s);
   msg = msg + "    Op2   : " + tmp + "\n";
-  meta_set_to_string(rv_validator->ops.op3 != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.op3] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.op3 != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.op3] : nullptr, tmp, s);
   msg = msg + "    Op3   : " + tmp + "\n";
-  meta_set_to_string(rv_validator->ops.mem != policy_engine::BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.mem] : nullptr, tmp, s);
+  meta_set_to_string(rv_validator->ops.mem != BAD_TAG_VALUE ? &rv_validator->ms_cache[rv_validator->ops.mem] : nullptr, tmp, s);
   msg = msg + "    Mem   : " + tmp + "\n";
 
   msg = msg + "\nResults:\n";

--- a/validator/riscv/main.cc
+++ b/validator/riscv/main.cc
@@ -200,7 +200,7 @@ void e_v_reg_tag(char* dest, int n, uint64_t addr) {
 
 void e_v_mem_tag(char* dest, int n, uint64_t addr) {
   if (addr <= rv_validator->address_max()) {
-    if (meta_set_t* ms = rv_validator->get_meta_set(static_cast<address_t>(addr))) {
+    if (const meta_set_t* ms = rv_validator->get_meta_set(static_cast<address_t>(addr))) {
       meta_set_to_string(ms, dest, n);
     } else {
       std::snprintf(dest, n, "Bad Address: %lx\n", addr);

--- a/validator/riscv/meta_cache.cc
+++ b/validator/riscv/meta_cache.cc
@@ -16,7 +16,7 @@ bool operator ==(const meta_set_t& lhs, const meta_set_t& rhs) {
 
 bool operator !=(const meta_set_t& lhs, const meta_set_t& rhs) { return !(lhs == rhs); }
 
-meta_set_t& meta_set_cache_t::canonize(const meta_set_t& ts) {
+const meta_set_t& meta_set_cache_t::canonize(const meta_set_t& ts) {
   for (meta_set_t& ms : canon)
     if (ms == ts)
       return ms;
@@ -25,14 +25,14 @@ meta_set_t& meta_set_cache_t::canonize(const meta_set_t& ts) {
   return canon.back();
 }
 
-meta_set_t& meta_set_cache_t::canonize(const metadata_t& md) {
+const meta_set_t& meta_set_cache_t::canonize(const metadata_t& md) {
   meta_set_t ms{0};
   for (const meta_t& e : md)
     ms_bit_add(&ms, e);
   return canonize(ms);
 }
 
-meta_set_t* meta_set_cache_t::operator [](tag_t tag) {
+const meta_set_t* meta_set_cache_t::operator [](tag_t tag) {
   return tags.at(tag);
 }
 

--- a/validator/riscv/meta_cache.cc
+++ b/validator/riscv/meta_cache.cc
@@ -1,5 +1,3 @@
-#include <functional>
-#include <stdexcept>
 #include "meta_cache.h"
 #include "metadata.h"
 #include "policy_meta_set.h"
@@ -17,12 +15,11 @@ bool operator ==(const meta_set_t& lhs, const meta_set_t& rhs) {
 bool operator !=(const meta_set_t& lhs, const meta_set_t& rhs) { return !(lhs == rhs); }
 
 tag_t meta_set_cache_t::canonize(const meta_set_t& ts) {
-  for (const auto& [ tag, ms ] : tags)
-    if (*ms == ts)
-      return tag;
-  canon.push_back(ts);
-  tags[canon.size() - 1] = &canon.back();
-  return canon.size() - 1;
+  for (int i = 0; i < meta_sets.size(); i++)
+    if (meta_sets[i] == ts)
+      return i;
+  meta_sets.push_back(ts);
+  return meta_sets.size() - 1;
 }
 
 tag_t meta_set_cache_t::canonize(const metadata_t& md) {

--- a/validator/riscv/meta_cache.cc
+++ b/validator/riscv/meta_cache.cc
@@ -1,5 +1,5 @@
 #include <functional>
-#include <iostream>
+#include <stdexcept>
 #include "meta_cache.h"
 #include "metadata.h"
 #include "policy_meta_set.h"
@@ -33,18 +33,16 @@ meta_set_t& meta_set_cache_t::canonize(const metadata_t& md) {
 }
 
 meta_set_t* meta_set_cache_t::operator [](tag_t tag) {
-  if (tag == 0 || tag > canon.size())
-    return nullptr;
-  return tags[tag];
+  return tags.at(tag);
 }
 
 tag_t meta_set_cache_t::tag_of(const meta_set_t* msp) {
-  if (msp == nullptr)
-    return 0;
   for (const auto& [ tag, sp ] : tags)
     if (sp == msp)
       return tag;
-  return 0;
+  char buf[64];
+  std::sprintf(buf, "no tag for meta set at %p", msp);
+  throw std::out_of_range(buf);
 }
 
 } // namespace policy_engine

--- a/validator/riscv/meta_cache.cc
+++ b/validator/riscv/meta_cache.cc
@@ -21,10 +21,7 @@ meta_set_t& meta_set_cache_t::canonize(const meta_set_t& ts) {
     if (ms == ts)
       return ms;
   canon.push_back(ts);
-
-  m2t[&canon.back()] = reinterpret_cast<tag_t>(&canon.back());
-  t2m[m2t[&canon.back()]] = &canon.back();
-
+  tags[canon.size()] = &canon.back();
   return canon.back();
 }
 
@@ -35,16 +32,19 @@ meta_set_t& meta_set_cache_t::canonize(const metadata_t& md) {
   return canonize(ms);
 }
 
-meta_set_t* meta_set_cache_t::operator [](tag_t tag) const {
-  if (tag == 0)
+meta_set_t* meta_set_cache_t::operator [](tag_t tag) {
+  if (tag == 0 || tag > canon.size())
     return nullptr;
-  return t2m.at(tag);
+  return tags[tag];
 }
 
-tag_t meta_set_cache_t::to_tag(meta_set_t* msp) const {
-  if (m2t.find(msp) == m2t.end())
+tag_t meta_set_cache_t::tag_of(const meta_set_t* msp) {
+  if (msp == nullptr)
     return 0;
-  return m2t.at(msp);
+  for (const auto& [ tag, sp ] : tags)
+    if (sp == msp)
+      return tag;
+  return 0;
 }
 
-}
+} // namespace policy_engine

--- a/validator/riscv/meta_cache.cc
+++ b/validator/riscv/meta_cache.cc
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "meta_cache.h"
 #include "metadata.h"
 #include "policy_meta_set.h"
@@ -18,6 +19,8 @@ tag_t meta_set_cache_t::canonize(const meta_set_t& ts) {
   for (int i = 0; i < meta_sets.size(); i++)
     if (meta_sets[i] == ts)
       return i;
+  if (meta_sets.size() == meta_sets.capacity())
+    std::cout << "reallocating meta set vector to increase capacity may invalidate tags that are pointers" << std::endl;
   meta_sets.push_back(ts);
   return meta_sets.size() - 1;
 }

--- a/validator/riscv/meta_cache.cc
+++ b/validator/riscv/meta_cache.cc
@@ -16,33 +16,20 @@ bool operator ==(const meta_set_t& lhs, const meta_set_t& rhs) {
 
 bool operator !=(const meta_set_t& lhs, const meta_set_t& rhs) { return !(lhs == rhs); }
 
-const meta_set_t& meta_set_cache_t::canonize(const meta_set_t& ts) {
-  for (meta_set_t& ms : canon)
-    if (ms == ts)
-      return ms;
+tag_t meta_set_cache_t::canonize(const meta_set_t& ts) {
+  for (const auto& [ tag, ms ] : tags)
+    if (*ms == ts)
+      return tag;
   canon.push_back(ts);
-  tags[canon.size()] = &canon.back();
-  return canon.back();
+  tags[canon.size() - 1] = &canon.back();
+  return canon.size() - 1;
 }
 
-const meta_set_t& meta_set_cache_t::canonize(const metadata_t& md) {
+tag_t meta_set_cache_t::canonize(const metadata_t& md) {
   meta_set_t ms{0};
   for (const meta_t& e : md)
     ms_bit_add(&ms, e);
   return canonize(ms);
-}
-
-const meta_set_t* meta_set_cache_t::operator [](tag_t tag) {
-  return tags.at(tag);
-}
-
-tag_t meta_set_cache_t::tag_of(const meta_set_t* msp) {
-  for (const auto& [ tag, sp ] : tags)
-    if (sp == msp)
-      return tag;
-  char buf[64];
-  std::sprintf(buf, "no tag for meta set at %p", msp);
-  throw std::out_of_range(buf);
 }
 
 } // namespace policy_engine

--- a/validator/riscv/meta_cache.h
+++ b/validator/riscv/meta_cache.h
@@ -45,11 +45,10 @@ private:
   std::unordered_map<tag_t, meta_set_t*> tags;
 
 public:
-  const meta_set_t& canonize(const meta_set_t& ts);
-  const meta_set_t& canonize(const metadata_t& md);
+  tag_t canonize(const meta_set_t& ts);
+  tag_t canonize(const metadata_t& md);
 
-  const meta_set_t* operator [](tag_t tag);
-  tag_t tag_of(const meta_set_t* msp);
+  const meta_set_t* operator [](tag_t tag) const { return tags.at(tag); }
 };
 
 } // namespace policy_engine

--- a/validator/riscv/meta_cache.h
+++ b/validator/riscv/meta_cache.h
@@ -45,10 +45,10 @@ private:
   std::unordered_map<tag_t, meta_set_t*> tags;
 
 public:
-  meta_set_t& canonize(const meta_set_t& ts);
-  meta_set_t& canonize(const metadata_t& md);
+  const meta_set_t& canonize(const meta_set_t& ts);
+  const meta_set_t& canonize(const metadata_t& md);
 
-  meta_set_t* operator [](tag_t tag);
+  const meta_set_t* operator [](tag_t tag);
   tag_t tag_of(const meta_set_t* msp);
 };
 

--- a/validator/riscv/meta_cache.h
+++ b/validator/riscv/meta_cache.h
@@ -42,15 +42,14 @@ bool operator !=(const meta_set_t& lhs, const meta_set_t& rhs);
 class meta_set_cache_t {
 private:
   std::list<meta_set_t> canon;
-  std::unordered_map<meta_set_t*, tag_t> m2t;
-  std::unordered_map<tag_t, meta_set_t*> t2m;
+  std::unordered_map<tag_t, meta_set_t*> tags;
 
 public:
   meta_set_t& canonize(const meta_set_t& ts);
   meta_set_t& canonize(const metadata_t& md);
 
-  meta_set_t* operator [](tag_t tag) const;
-  tag_t to_tag(meta_set_t* msp) const;
+  meta_set_t* operator [](tag_t tag);
+  tag_t tag_of(const meta_set_t* msp);
 };
 
 } // namespace policy_engine

--- a/validator/riscv/meta_cache.h
+++ b/validator/riscv/meta_cache.h
@@ -42,6 +42,8 @@ private:
   std::vector<meta_set_t> meta_sets;
 
 public:
+  meta_set_cache_t() { meta_sets.reserve(1024); }
+
   tag_t canonize(const meta_set_t& ts);
   tag_t canonize(const metadata_t& md);
 

--- a/validator/riscv/meta_cache.h
+++ b/validator/riscv/meta_cache.h
@@ -27,9 +27,7 @@
 #ifndef META_CACHE_H
 #define META_CACHE_H
 
-#include <list>
-#include <memory>
-#include <unordered_map>
+#include <vector>
 #include "metadata.h"
 #include "policy_meta_set.h"
 #include "tag_utils.h"
@@ -41,14 +39,13 @@ bool operator !=(const meta_set_t& lhs, const meta_set_t& rhs);
 
 class meta_set_cache_t {
 private:
-  std::list<meta_set_t> canon;
-  std::unordered_map<tag_t, meta_set_t*> tags;
+  std::vector<meta_set_t> meta_sets;
 
 public:
   tag_t canonize(const meta_set_t& ts);
   tag_t canonize(const metadata_t& md);
 
-  const meta_set_t* operator [](tag_t tag) const { return tags.at(tag); }
+  const meta_set_t& operator [](tag_t tag) const { return meta_sets.at(tag); }
 };
 
 } // namespace policy_engine

--- a/validator/riscv/meta_set_factory.cc
+++ b/validator/riscv/meta_set_factory.cc
@@ -32,7 +32,7 @@
 
 namespace policy_engine {
 
-meta_set_t* meta_set_factory_t::get_meta_set(const std::string& dotted_path) {
+const meta_set_t* meta_set_factory_t::get_meta_set(const std::string& dotted_path) {
   const metadata_t* metadata = lookup_metadata(dotted_path);
   if (metadata) {
     meta_set_t ms;

--- a/validator/riscv/meta_set_factory.cc
+++ b/validator/riscv/meta_set_factory.cc
@@ -32,7 +32,7 @@
 
 namespace policy_engine {
 
-const meta_set_t* meta_set_factory_t::get_meta_set(const std::string& dotted_path) {
+tag_t meta_set_factory_t::get_tag(const std::string& dotted_path) {
   const metadata_t* metadata = lookup_metadata(dotted_path);
   if (metadata) {
     meta_set_t ms;
@@ -40,9 +40,9 @@ const meta_set_t* meta_set_factory_t::get_meta_set(const std::string& dotted_pat
     for (const meta_t& m: *metadata) {
       ms_bit_add(&ms, m);
     }
-    return &ms_cache->canonize(ms);
+    return ms_cache->canonize(ms);
   } else {
-    return nullptr;
+    return BAD_TAG_VALUE;
   }
 }
 

--- a/validator/riscv/meta_set_factory.h
+++ b/validator/riscv/meta_set_factory.h
@@ -40,6 +40,7 @@ private:
 
 public:
   meta_set_factory_t(meta_set_cache_t* ms_cache, const std::string& policy_dir) : metadata_factory_t(policy_dir), ms_cache(ms_cache) {}
+  bool has_meta_set(const std::string& dotted_path) { return lookup_metadata(dotted_path) != nullptr; }
   meta_set_t* get_meta_set(const std::string& dotted_path);
   meta_set_t* get_group_meta_set(const std::string& opgroup) { return nullptr; }
 };

--- a/validator/riscv/meta_set_factory.h
+++ b/validator/riscv/meta_set_factory.h
@@ -41,8 +41,8 @@ private:
 public:
   meta_set_factory_t(meta_set_cache_t* ms_cache, const std::string& policy_dir) : metadata_factory_t(policy_dir), ms_cache(ms_cache) {}
   bool has_meta_set(const std::string& dotted_path) { return lookup_metadata(dotted_path) != nullptr; }
-  meta_set_t* get_meta_set(const std::string& dotted_path);
-  meta_set_t* get_group_meta_set(const std::string& opgroup) { return nullptr; }
+  const meta_set_t* get_meta_set(const std::string& dotted_path);
+  const meta_set_t* get_group_meta_set(const std::string& opgroup) { return nullptr; }
 };
 
 } // namespace policy_engine

--- a/validator/riscv/meta_set_factory.h
+++ b/validator/riscv/meta_set_factory.h
@@ -31,6 +31,7 @@
 #include "meta_cache.h"
 #include "metadata_factory.h"
 #include "policy_meta_set.h"
+#include "tag_types.h"
 
 namespace policy_engine {
 

--- a/validator/riscv/meta_set_factory.h
+++ b/validator/riscv/meta_set_factory.h
@@ -41,8 +41,8 @@ private:
 public:
   meta_set_factory_t(meta_set_cache_t* ms_cache, const std::string& policy_dir) : metadata_factory_t(policy_dir), ms_cache(ms_cache) {}
   bool has_meta_set(const std::string& dotted_path) { return lookup_metadata(dotted_path) != nullptr; }
-  const meta_set_t* get_meta_set(const std::string& dotted_path);
-  const meta_set_t* get_group_meta_set(const std::string& opgroup) { return nullptr; }
+  tag_t get_tag(const std::string& dotted_path);
+  tag_t get_group_tag(const std::string& opgroup) { return BAD_TAG_VALUE; }
 };
 
 } // namespace policy_engine

--- a/validator/riscv/rv_validator.cc
+++ b/validator/riscv/rv_validator.cc
@@ -51,13 +51,10 @@ rv_validator_t::rv_validator_t(int xlen, const std::string& policy_dir, const st
     sim_validator_t(rr, af), tag_based_validator_t(policy_dir), res({new meta_set_t{0}, new meta_set_t{0}, new meta_set_t{0}, true, true, true}),
     xlen(xlen), watch_pc(false), rule_cache(nullptr), failed(false), has_insn_mem_addr(false), rule_cache_hits(0), rule_cache_misses(0) {
   ireg_tags.fill(ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.Reg.Default")));
-  ireg_tags[0] = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.Reg.RZero"));
+  if (ms_factory.has_meta_set("ISA.RISCV.Reg.RZero"))
+    ireg_tags[0] = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.Reg.RZero"));
   csr_tags.fill(ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.CSR.Default")));
   pc_tag = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.Reg.Env"));
-  // set initial tags for specific CSRs
-  csr_tags[CSR_MEPC] = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.CSR.MEPC"));
-  csr_tags[CSR_MTVAL] = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.CSR.MTVal"));
-  csr_tags[CSR_MTVEC] = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.CSR.MTVec"));
 
   soc_tag_configuration_t config(&ms_factory, soc_cfg, xlen);
   config.apply(&tag_bus, &ms_cache);
@@ -73,7 +70,7 @@ rv_validator_t::~rv_validator_t() {
 }
 
 void rv_validator_t::apply_metadata(const metadata_memory_map_t* md_map) {
-  for (const auto [ range, metadata ]: *md_map) {
+  for (const auto [ range, metadata ] : *md_map) {
     for (address_t start = range.start; start < range.end; start += 4) {
       try {
         tag_bus.insn_tag_at(start) = ms_cache.tag_of(&ms_cache.canonize(*metadata));

--- a/validator/riscv/rv_validator.cc
+++ b/validator/riscv/rv_validator.cc
@@ -81,7 +81,7 @@ void rv_validator_t::apply_metadata(const metadata_memory_map_t* md_map) {
   }
 }
 
-void rv_validator_t::handle_violation(context_t* ctx, operands_t* ops){
+void rv_validator_t::handle_violation(context_t* ctx, const operands_t* ops){
   if (!failed) {
     failed = true;
     memcpy(&failed_ctx, ctx, sizeof(context_t));

--- a/validator/riscv/rv_validator.cc
+++ b/validator/riscv/rv_validator.cc
@@ -120,7 +120,7 @@ bool rv_validator_t::validate(address_t pc, insn_bits_t insn) {
   setup_validation();
   prepare_eval(pc, insn);
   if (rule_cache) {
-    if (rule_cache->allow(&ops, &res)) {
+    if (rule_cache->allow(ops, res)) {
       rule_cache_hits++;
       rule_cache_hit = true;
       return true;
@@ -196,7 +196,7 @@ bool rv_validator_t::commit() {
   }
 
   if (has_pending_CSR && res.csrResult) {
-    tag_t new_tag = ms_cache.tag_of(&ms_cache.canonize(*res.csr));
+    tag_t new_tag = ms_cache.tag_of(res.csr);
     for (const address_t& csr : watch_csrs) {
       if (pending_CSR == csr && csr_tags[pending_CSR] != new_tag){
         printf("Watch tag CSR\n");
@@ -209,8 +209,8 @@ bool rv_validator_t::commit() {
 
   if (rule_cache) {
     results_t res_copy(res);
-    if (ctx.cached && !rule_cache->allow(&ops, &res)) {
-      rule_cache->install_rule(&ops, &res_copy);
+    if (ctx.cached && !rule_cache->allow(ops, res)) {
+      rule_cache->install_rule(ops, res_copy);
     }
   }
   return hit_watch;

--- a/validator/riscv/rv_validator.cc
+++ b/validator/riscv/rv_validator.cc
@@ -89,26 +89,10 @@ void rv_validator_t::handle_violation(context_t* ctx, const operands_t* ops){
   }
 }
 
-meta_set_t empty_set{0};
-
 void rv_validator_t::setup_validation() {
   ctx = {0, 0, 0, "", "", true};
   ops = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
-
-  if (res.pcResult) {
-    res.pc = &empty_set;
-    res.pcResult = false;
-  }
-
-  if (res.rdResult) {
-    res.rd = &empty_set;
-    res.rdResult = false;
-  }
-
-  if (res.csrResult) {
-    res.csr = &empty_set;
-    res.csrResult = false;
-  }
+  res = {nullptr, nullptr, nullptr, false, false, false};
 }
 
 std::pair<bool, bool> rv_validator_t::validate(address_t pc, insn_bits_t insn, address_t memory_addr) {

--- a/validator/riscv/rv_validator.cc
+++ b/validator/riscv/rv_validator.cc
@@ -89,22 +89,24 @@ void rv_validator_t::handle_violation(context_t* ctx, const operands_t* ops){
   }
 }
 
+meta_set_t empty_set{0};
+
 void rv_validator_t::setup_validation() {
   ctx = {0, 0, 0, "", "", true};
   ops = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 
   if (res.pcResult) {
-    memset(res.pc, 0, sizeof(meta_set_t));
+    res.pc = &empty_set;
     res.pcResult = false;
   }
 
   if (res.rdResult) {
-    memset(res.rd, 0, sizeof(meta_set_t));
+    res.rd = &empty_set;
     res.rdResult = false;
   }
 
   if (res.csrResult) {
-    memset(res.csr, 0, sizeof(meta_set_t));
+    res.csr = &empty_set;
     res.csrResult = false;
   }
 }

--- a/validator/riscv/rv_validator.cc
+++ b/validator/riscv/rv_validator.cc
@@ -145,7 +145,7 @@ bool rv_validator_t::commit() {
   bool hit_watch = false;
 
   if (res.pcResult) {
-    tag_t new_tag = ms_cache.tag_of(&ms_cache.canonize(*res.pc));
+    tag_t new_tag = ms_cache.tag_of(res.pc);
     if (watch_pc && pc_tag != new_tag) {
       std::cout << "Watch tag pc" << std::endl;
       hit_watch = true;
@@ -154,7 +154,7 @@ bool rv_validator_t::commit() {
   }
 
   if (has_pending_RD && res.rdResult) {
-    tag_t new_tag = ms_cache.tag_of(&ms_cache.canonize(*res.rd));
+    tag_t new_tag = ms_cache.tag_of(res.rd);
     for (const address_t& reg : watch_regs) {
       if (pending_RD == reg && ireg_tags[pending_RD] != new_tag) {
         std::cout << "Watch tag reg" << std::endl;
@@ -168,7 +168,7 @@ bool rv_validator_t::commit() {
   }
   
   if (has_pending_mem && res.rdResult) {
-    tag_t new_tag = ms_cache.tag_of(&ms_cache.canonize(*res.rd));
+    tag_t new_tag = ms_cache.tag_of(res.rd);
     tag_t old_tag;
     address_t mem_paddr = addr_fixer(mem_addr);
     try {
@@ -208,15 +208,7 @@ bool rv_validator_t::commit() {
   }
 
   if (rule_cache) {
-    results_t res_copy = {
-      .pc = &ms_cache.canonize(*res.pc),
-      .rd = &ms_cache.canonize(*res.rd),
-      .csr = &ms_cache.canonize(*res.csr),
-      .pcResult = res.pcResult,
-      .rdResult = res.rdResult,
-      .csrResult = res.csrResult
-    };
-
+    results_t res_copy(res);
     if (ctx.cached && !rule_cache->allow(&ops, &res)) {
       rule_cache->install_rule(&ops, &res_copy);
     }

--- a/validator/riscv/rv_validator.cc
+++ b/validator/riscv/rv_validator.cc
@@ -48,22 +48,19 @@ static std::string tag_name(const meta_set_t* tag) {
 }
 
 rv_validator_t::rv_validator_t(int xlen, const std::string& policy_dir, const std::string& soc_cfg, RegisterReader_t rr, AddressFixer_t af) :
-    sim_validator_t(rr, af), tag_based_validator_t(policy_dir), res({new meta_set_t{0}, new meta_set_t{0}, new meta_set_t{0}, true, true, true}),
+    sim_validator_t(rr, af), tag_based_validator_t(policy_dir), res({BAD_TAG_VALUE, BAD_TAG_VALUE, BAD_TAG_VALUE, true, true, true}),
     xlen(xlen), watch_pc(false), rule_cache(nullptr), failed(false), has_insn_mem_addr(false), rule_cache_hits(0), rule_cache_misses(0) {
-  ireg_tags.fill(ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.Reg.Default")));
+  ireg_tags.fill(ms_factory.get_tag("ISA.RISCV.Reg.Default"));
   if (ms_factory.has_meta_set("ISA.RISCV.Reg.RZero"))
-    ireg_tags[0] = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.Reg.RZero"));
-  csr_tags.fill(ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.CSR.Default")));
-  pc_tag = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.Reg.Env"));
+    ireg_tags[0] = ms_factory.get_tag("ISA.RISCV.Reg.RZero");
+  csr_tags.fill(ms_factory.get_tag("ISA.RISCV.CSR.Default"));
+  pc_tag = ms_factory.get_tag("ISA.RISCV.Reg.Env");
 
   soc_tag_configuration_t config(&ms_factory, soc_cfg, xlen);
   config.apply(&tag_bus, &ms_cache);
 }
 
 rv_validator_t::~rv_validator_t() {
-  delete res.pc;
-  delete res.rd;
-  delete res.csr;
   if (rule_cache) {
     delete rule_cache;
   }
@@ -73,7 +70,7 @@ void rv_validator_t::apply_metadata(const metadata_memory_map_t* md_map) {
   for (const auto [ range, metadata ] : *md_map) {
     for (address_t start = range.start; start < range.end; start += 4) {
       try {
-        tag_bus.insn_tag_at(start) = ms_cache.tag_of(&ms_cache.canonize(*metadata));
+        tag_bus.insn_tag_at(start) = ms_cache.canonize(*metadata);
       } catch (const std::out_of_range& e) {
         throw configuration_exception_t("unable to apply metadata");
       }
@@ -90,9 +87,11 @@ void rv_validator_t::handle_violation(context_t* ctx, const operands_t* ops){
 }
 
 void rv_validator_t::setup_validation() {
+  meta_set_t empty{0};
+
   ctx = {0, 0, 0, "", "", true};
-  ops = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
-  res = {nullptr, nullptr, nullptr, false, false, false};
+  ops = {BAD_TAG_VALUE, BAD_TAG_VALUE, BAD_TAG_VALUE, BAD_TAG_VALUE, BAD_TAG_VALUE, BAD_TAG_VALUE};
+  res = {ms_cache.canonize(empty), ms_cache.canonize(empty), ms_cache.canonize(empty), false, false, false};
 }
 
 std::pair<bool, bool> rv_validator_t::validate(address_t pc, insn_bits_t insn, address_t memory_addr) {
@@ -145,30 +144,27 @@ bool rv_validator_t::commit() {
   bool hit_watch = false;
 
   if (res.pcResult) {
-    tag_t new_tag = ms_cache.tag_of(res.pc);
-    if (watch_pc && pc_tag != new_tag) {
+    if (watch_pc && pc_tag != res.pc) {
       std::cout << "Watch tag pc" << std::endl;
       hit_watch = true;
     }
-    pc_tag = new_tag;
+    pc_tag = res.pc;
   }
 
   if (has_pending_RD && res.rdResult) {
-    tag_t new_tag = ms_cache.tag_of(res.rd);
     for (const address_t& reg : watch_regs) {
-      if (pending_RD == reg && ireg_tags[pending_RD] != new_tag) {
+      if (pending_RD == reg && ireg_tags[pending_RD] != res.rd) {
         std::cout << "Watch tag reg" << std::endl;
         hit_watch = true;
       }
     }
 
     // dont update metadata on regZero
-    if(pending_RD)
-        ireg_tags[pending_RD] = new_tag;
+    if (pending_RD)
+        ireg_tags[pending_RD] = res.rd;
   }
   
   if (has_pending_mem && res.rdResult) {
-    tag_t new_tag = ms_cache.tag_of(res.rd);
     tag_t old_tag;
     address_t mem_paddr = addr_fixer(mem_addr);
     try {
@@ -179,7 +175,7 @@ bool rv_validator_t::commit() {
     }
 
     for (const address_t& addr : watch_addrs) {
-      if (mem_addr == addr && old_tag != new_tag){
+      if (mem_addr == addr && old_tag != res.rd){
         address_t epc_addr = ctx.epc;
         std::printf("Watch tag mem at PC 0x%" PRIaddr "\n", epc_addr);
         hit_watch = true;
@@ -187,7 +183,7 @@ bool rv_validator_t::commit() {
     }
 
     try {
-      tag_bus.data_tag_at(mem_paddr) = new_tag;
+      tag_bus.data_tag_at(mem_paddr) = res.rd;
     } catch (const std::out_of_range& e) {
       printf("failed to store MR tag @ 0x%" PRIaddr " (0x%" PRIaddr ")\n", mem_addr, mem_paddr);
       fflush(stdout);
@@ -196,15 +192,14 @@ bool rv_validator_t::commit() {
   }
 
   if (has_pending_CSR && res.csrResult) {
-    tag_t new_tag = ms_cache.tag_of(res.csr);
     for (const address_t& csr : watch_csrs) {
-      if (pending_CSR == csr && csr_tags[pending_CSR] != new_tag){
+      if (pending_CSR == csr && csr_tags[pending_CSR] != res.csr){
         printf("Watch tag CSR\n");
         fflush(stdout);
         hit_watch = true;
       }
     }
-    csr_tags[pending_CSR] = new_tag;
+    csr_tags[pending_CSR] = res.csr;
   }
 
   if (rule_cache) {
@@ -227,10 +222,10 @@ void rv_validator_t::prepare_eval(address_t pc, insn_bits_t insn) {
   }
   pending_RD = inst.rd.getOrElse(-1);
 
-  if (inst.rs1) ops.op1 = ms_cache[ireg_tags[inst.rs1]];
-  if (inst.flags.has_csr_load || inst.flags.has_csr_store) ops.op2 = ms_cache[csr_tags[inst.imm]];
-  if (inst.rs2) ops.op2 = ms_cache[ireg_tags[inst.rs2]];
-  if (inst.rs3) ops.op3 = ms_cache[ireg_tags[inst.rs3]];
+  if (inst.rs1) ops.op1 = ireg_tags[inst.rs1];
+  if (inst.flags.has_csr_load || inst.flags.has_csr_store) ops.op2 = csr_tags[inst.imm];
+  if (inst.rs2) ops.op2 = ireg_tags[inst.rs2];
+  if (inst.rs3) ops.op3 = ireg_tags[inst.rs3];
   has_pending_CSR = inst.flags.has_csr_store;
   has_pending_RD = inst.rd.exists;
   has_pending_mem = inst.flags.has_store;
@@ -255,9 +250,8 @@ void rv_validator_t::prepare_eval(address_t pc, insn_bits_t insn) {
     address_t mem_paddr = addr_fixer(mem_addr);
     ctx.bad_addr = mem_addr;
     try {
-      tag_t mtag = tag_bus.data_tag_at(mem_paddr);
-      ops.mem = ms_cache[mtag];
-      if (!ops.mem) {
+      ops.mem = tag_bus.data_tag_at(mem_paddr);
+      if (ops.mem == BAD_TAG_VALUE) {
         char buf[128];
         sprintf(buf, "TMT miss for memory (0x%" PRIaddr " (0x%" PRIaddr ")) at instruction 0x%" PRIaddr ". TMT misses are fatal.\n", mem_addr, mem_paddr, pc);
         throw std::runtime_error(buf);
@@ -267,15 +261,15 @@ void rv_validator_t::prepare_eval(address_t pc, insn_bits_t insn) {
     }
   }
 
-  tag_t ci_tag;
+  tag_t ci_tag = BAD_TAG_VALUE;
   try {
     ci_tag = tag_bus.insn_tag_at(pc_paddr);
   } catch (const std::out_of_range& e) {
     printf("failed to load CI tag for PC 0x%" PRIaddr " (0x%" PRIaddr ")\n", pc, pc_paddr);
   }
   ctx.epc = pc;
-  ops.ci = ms_cache[ci_tag];
-  ops.pc = ms_cache[pc_tag];
+  ops.ci = ci_tag;
+  ops.pc = pc_tag;
 }
 
 void rv_validator_t::complete_eval() {}
@@ -289,7 +283,7 @@ void rv_validator_t::config_rule_cache(const std::string& rule_cache_name, int c
   } else if (name_lower == "finite") {
     rule_cache = new finite_rule_cache_t(capacity);
   } else if (name_lower == "dmhc") {
-    rule_cache = new dmhc_rule_cache_t(capacity, DMHC_RULE_CACHE_IWIDTH, DMHC_RULE_CACHE_OWIDTH, DMHC_RULE_CACHE_K, DMHC_RULE_CACHE_NO_EVICT);
+    rule_cache = new dmhc_rule_cache_t(capacity, DMHC_RULE_CACHE_IWIDTH, DMHC_RULE_CACHE_OWIDTH, DMHC_RULE_CACHE_K, DMHC_RULE_CACHE_NO_EVICT, &ms_cache);
   } else if (rule_cache_name.size() != 0) {
     throw configuration_exception_t("Invalid rule cache name");
   }

--- a/validator/riscv/rv_validator.cc
+++ b/validator/riscv/rv_validator.cc
@@ -50,14 +50,14 @@ static std::string tag_name(const meta_set_t* tag) {
 rv_validator_t::rv_validator_t(int xlen, const std::string& policy_dir, const std::string& soc_cfg, RegisterReader_t rr, AddressFixer_t af) :
     sim_validator_t(rr, af), tag_based_validator_t(policy_dir), res({new meta_set_t{0}, new meta_set_t{0}, new meta_set_t{0}, true, true, true}),
     xlen(xlen), watch_pc(false), rule_cache(nullptr), failed(false), has_insn_mem_addr(false), rule_cache_hits(0), rule_cache_misses(0) {
-  ireg_tags.fill(ms_cache.to_tag(ms_factory.get_meta_set("ISA.RISCV.Reg.Default")));
-  ireg_tags[0] = ms_cache.to_tag(ms_factory.get_meta_set("ISA.RISCV.Reg.RZero"));
-  csr_tags.fill(ms_cache.to_tag(ms_factory.get_meta_set("ISA.RISCV.CSR.Default")));
-  pc_tag = ms_cache.to_tag(ms_factory.get_meta_set("ISA.RISCV.Reg.Env"));
+  ireg_tags.fill(ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.Reg.Default")));
+  ireg_tags[0] = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.Reg.RZero"));
+  csr_tags.fill(ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.CSR.Default")));
+  pc_tag = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.Reg.Env"));
   // set initial tags for specific CSRs
-  csr_tags[CSR_MEPC] = ms_cache.to_tag(ms_factory.get_meta_set("ISA.RISCV.CSR.MEPC"));
-  csr_tags[CSR_MTVAL] = ms_cache.to_tag(ms_factory.get_meta_set("ISA.RISCV.CSR.MTVal"));
-  csr_tags[CSR_MTVEC] = ms_cache.to_tag(ms_factory.get_meta_set("ISA.RISCV.CSR.MTVec"));
+  csr_tags[CSR_MEPC] = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.CSR.MEPC"));
+  csr_tags[CSR_MTVAL] = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.CSR.MTVal"));
+  csr_tags[CSR_MTVEC] = ms_cache.tag_of(ms_factory.get_meta_set("ISA.RISCV.CSR.MTVec"));
 
   soc_tag_configuration_t config(&ms_factory, soc_cfg, xlen);
   config.apply(&tag_bus, &ms_cache);
@@ -76,7 +76,7 @@ void rv_validator_t::apply_metadata(const metadata_memory_map_t* md_map) {
   for (const auto [ range, metadata ]: *md_map) {
     for (address_t start = range.start; start < range.end; start += 4) {
       try {
-        tag_bus.insn_tag_at(start) = ms_cache.to_tag(&ms_cache.canonize(*metadata));
+        tag_bus.insn_tag_at(start) = ms_cache.tag_of(&ms_cache.canonize(*metadata));
       } catch (const std::out_of_range& e) {
         throw configuration_exception_t("unable to apply metadata");
       }
@@ -162,7 +162,7 @@ bool rv_validator_t::commit() {
   bool hit_watch = false;
 
   if (res.pcResult) {
-    tag_t new_tag = ms_cache.to_tag(&ms_cache.canonize(*res.pc));
+    tag_t new_tag = ms_cache.tag_of(&ms_cache.canonize(*res.pc));
     if (watch_pc && pc_tag != new_tag) {
       std::cout << "Watch tag pc" << std::endl;
       hit_watch = true;
@@ -171,7 +171,7 @@ bool rv_validator_t::commit() {
   }
 
   if (has_pending_RD && res.rdResult) {
-    tag_t new_tag = ms_cache.to_tag(&ms_cache.canonize(*res.rd));
+    tag_t new_tag = ms_cache.tag_of(&ms_cache.canonize(*res.rd));
     for (const address_t& reg : watch_regs) {
       if (pending_RD == reg && ireg_tags[pending_RD] != new_tag) {
         std::cout << "Watch tag reg" << std::endl;
@@ -185,7 +185,7 @@ bool rv_validator_t::commit() {
   }
   
   if (has_pending_mem && res.rdResult) {
-    tag_t new_tag = ms_cache.to_tag(&ms_cache.canonize(*res.rd));
+    tag_t new_tag = ms_cache.tag_of(&ms_cache.canonize(*res.rd));
     tag_t old_tag;
     address_t mem_paddr = addr_fixer(mem_addr);
     try {
@@ -213,7 +213,7 @@ bool rv_validator_t::commit() {
   }
 
   if (has_pending_CSR && res.csrResult) {
-    tag_t new_tag = ms_cache.to_tag(&ms_cache.canonize(*res.csr));
+    tag_t new_tag = ms_cache.tag_of(&ms_cache.canonize(*res.csr));
     for (const address_t& csr : watch_csrs) {
       if (pending_CSR == csr && csr_tags[pending_CSR] != new_tag){
         printf("Watch tag CSR\n");

--- a/validator/riscv/rv_validator.cc
+++ b/validator/riscv/rv_validator.cc
@@ -283,7 +283,7 @@ void rv_validator_t::config_rule_cache(const std::string& rule_cache_name, int c
   } else if (name_lower == "finite") {
     rule_cache = new finite_rule_cache_t(capacity);
   } else if (name_lower == "dmhc") {
-    rule_cache = new dmhc_rule_cache_t(capacity, DMHC_RULE_CACHE_IWIDTH, DMHC_RULE_CACHE_OWIDTH, DMHC_RULE_CACHE_K, DMHC_RULE_CACHE_NO_EVICT, &ms_cache);
+    rule_cache = new dmhc_rule_cache_t(capacity, DMHC_RULE_CACHE_IWIDTH, DMHC_RULE_CACHE_OWIDTH, DMHC_RULE_CACHE_K, DMHC_RULE_CACHE_NO_EVICT);
   } else if (rule_cache_name.size() != 0) {
     throw configuration_exception_t("Invalid rule cache name");
   }

--- a/validator/riscv/rv_validator.h
+++ b/validator/riscv/rv_validator.h
@@ -92,7 +92,7 @@ public:
 
   // Provides the tag for a given address.  Used for debugging.
   tag_t& get_tag(address_t addr) { return tag_bus.data_tag_at(addr); }
-  meta_set_t* get_meta_set(address_t addr) {
+  const meta_set_t* get_meta_set(address_t addr) {
     try {
       return ms_cache[get_tag(addr)];
     } catch (...) {
@@ -100,9 +100,9 @@ public:
     }
   }
 
-  meta_set_t* get_pc_meta_set() { return ms_cache[pc_tag]; }
-  meta_set_t* get_csr_meta_set(address_t csr) { return ms_cache[csr_tags[csr]]; }
-  meta_set_t* get_ireg_meta_set(address_t reg) { return ms_cache[ireg_tags[reg]]; }
+  const meta_set_t* get_pc_meta_set() { return ms_cache[pc_tag]; }
+  const meta_set_t* get_csr_meta_set(address_t csr) { return ms_cache[csr_tags[csr]]; }
+  const meta_set_t* get_ireg_meta_set(address_t reg) { return ms_cache[ireg_tags[reg]]; }
 
   void set_pc_watch(bool watching) { watch_pc = watching; }
   void set_reg_watch(address_t addr) { watch_regs.push_back(addr); }

--- a/validator/riscv/rv_validator.h
+++ b/validator/riscv/rv_validator.h
@@ -92,17 +92,10 @@ public:
 
   // Provides the tag for a given address.  Used for debugging.
   tag_t& get_tag(address_t addr) { return tag_bus.data_tag_at(addr); }
-  const meta_set_t* get_meta_set(address_t addr) {
-    try {
-      return ms_cache[get_tag(addr)];
-    } catch (...) {
-      return nullptr;
-    }
-  }
-
-  const meta_set_t* get_pc_meta_set() { return ms_cache[pc_tag]; }
-  const meta_set_t* get_csr_meta_set(address_t csr) { return ms_cache[csr_tags[csr]]; }
-  const meta_set_t* get_ireg_meta_set(address_t reg) { return ms_cache[ireg_tags[reg]]; }
+  const meta_set_t& get_meta_set(address_t addr) { return ms_cache[get_tag(addr)]; }
+  const meta_set_t& get_pc_meta_set() { return ms_cache[pc_tag]; }
+  const meta_set_t& get_csr_meta_set(address_t csr) { return ms_cache[csr_tags[csr]]; }
+  const meta_set_t& get_ireg_meta_set(address_t reg) { return ms_cache[ireg_tags[reg]]; }
 
   void set_pc_watch(bool watching) { watch_pc = watching; }
   void set_reg_watch(address_t addr) { watch_regs.push_back(addr); }

--- a/validator/riscv/rv_validator.h
+++ b/validator/riscv/rv_validator.h
@@ -84,7 +84,7 @@ public:
 
   void apply_metadata(const metadata_memory_map_t* md_map);
 
-  void handle_violation(context_t* ctx, operands_t* ops);
+  void handle_violation(context_t* ctx, const operands_t* ops);
 
   bool validate(address_t pc, insn_bits_t insn);
   std::pair<bool, bool> validate(address_t pc, insn_bits_t insn, address_t mem_addr);

--- a/validator/rule_cache/base_rule_cache.h
+++ b/validator/rule_cache/base_rule_cache.h
@@ -14,32 +14,4 @@ public:
 
 } // namespace policy_engine
 
-namespace std
-{
-
-template<>
-struct equal_to<policy_engine::operands_t> {
-  bool operator ()(const policy_engine::operands_t& a, const policy_engine::operands_t& b) const {
-    return (a.op1 == b.op1 && a.op2 == b.op2 && a.op3 == b.op3 && a.mem == b.mem && a.pc == b.pc && a.ci == b.ci);
-  }
-};
-
-template<>
-struct hash<policy_engine::operands_t> {
-  size_t operator ()(const policy_engine::operands_t& ops) const {
-    // XOR all meta_set_t pointers (operands) together.
-    // Shift pointers slightly so that two identical
-    // tags don't cancel out to 0.
-    size_t hash = reinterpret_cast<size_t>(ops.pc);
-    hash ^= reinterpret_cast<size_t>(ops.ci)  << 1;
-    hash ^= reinterpret_cast<size_t>(ops.op1) << 2;
-    hash ^= reinterpret_cast<size_t>(ops.op2) << 3;
-    hash ^= reinterpret_cast<size_t>(ops.op3) << 4;
-    hash ^= reinterpret_cast<size_t>(ops.mem) << 5;
-    return hash;
-  }
-};
-
-} // namespace std
-
 #endif// __BASE_RULE_CACHE_H__

--- a/validator/rule_cache/base_rule_cache.h
+++ b/validator/rule_cache/base_rule_cache.h
@@ -5,22 +5,11 @@
 
 namespace policy_engine {
 
-struct compare_ops {
-  bool operator()(const operands_t& a, const operands_t& b) const {
-    return (a.op1 == b.op1 &&
-            a.op2 == b.op2 &&
-            a.op3 == b.op3 &&
-            a.mem == b.mem &&
-            a.pc == b.pc &&
-            a.ci == b.ci);
-  }
-};
-
 class rule_cache_t {
 public:
   virtual void flush() = 0;
-  virtual void install_rule(const operands_t* ops, results_t* res) = 0;
-  virtual bool allow(const operands_t* ops, results_t* res) = 0;
+  virtual void install_rule(const operands_t& ops, const results_t& res) = 0;
+  virtual bool allow(const operands_t& ops, results_t& res) = 0;
 };
 
 } // namespace policy_engine
@@ -28,20 +17,25 @@ public:
 namespace std
 {
 
-template <>
-struct hash<policy_engine::operands_t>
-{
-  size_t operator()(const policy_engine::operands_t& ops) const
-  {
+template<>
+struct equal_to<policy_engine::operands_t> {
+  bool operator ()(const policy_engine::operands_t& a, const policy_engine::operands_t& b) const {
+    return (a.op1 == b.op1 && a.op2 == b.op2 && a.op3 == b.op3 && a.mem == b.mem && a.pc == b.pc && a.ci == b.ci);
+  }
+};
+
+template<>
+struct hash<policy_engine::operands_t> {
+  size_t operator ()(const policy_engine::operands_t& ops) const {
     // XOR all meta_set_t pointers (operands) together.
     // Shift pointers slightly so that two identical
     // tags don't cancel out to 0.
-    size_t hash = (size_t) ops.pc;
-    hash ^= (size_t) ops.ci  << 1;
-    hash ^= (size_t) ops.op1 << 2;
-    hash ^= (size_t) ops.op2 << 3;
-    hash ^= (size_t) ops.op3 << 4;
-    hash ^= (size_t) ops.mem << 5;
+    size_t hash = reinterpret_cast<size_t>(ops.pc);
+    hash ^= reinterpret_cast<size_t>(ops.ci)  << 1;
+    hash ^= reinterpret_cast<size_t>(ops.op1) << 2;
+    hash ^= reinterpret_cast<size_t>(ops.op2) << 3;
+    hash ^= reinterpret_cast<size_t>(ops.op3) << 4;
+    hash ^= reinterpret_cast<size_t>(ops.mem) << 5;
     return hash;
   }
 };

--- a/validator/rule_cache/base_rule_cache.h
+++ b/validator/rule_cache/base_rule_cache.h
@@ -6,7 +6,7 @@
 namespace policy_engine {
 
 struct compare_ops {
-  bool operator()(const operands_t &a, const operands_t &b) const {
+  bool operator()(const operands_t& a, const operands_t& b) const {
     return (a.op1 == b.op1 &&
             a.op2 == b.op2 &&
             a.op3 == b.op3 &&
@@ -19,8 +19,8 @@ struct compare_ops {
 class rule_cache_t {
 public:
   virtual void flush() = 0;
-  virtual void install_rule(operands_t *ops, results_t *res) = 0;
-  virtual bool allow(operands_t *ops, results_t *res) = 0;
+  virtual void install_rule(const operands_t* ops, results_t* res) = 0;
+  virtual bool allow(const operands_t* ops, results_t* res) = 0;
 };
 
 } // namespace policy_engine

--- a/validator/rule_cache/dmhc_rule_cache/compute_hash.cc
+++ b/validator/rule_cache/dmhc_rule_cache/compute_hash.cc
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include "compute_hash.h"
+#include "tag_types.h"
 
 #define UNASSIGNED -1
 // switch between 0-3 (original hashes) and 4-7 (random permutation hashes)

--- a/validator/rule_cache/dmhc_rule_cache/compute_hash.cc
+++ b/validator/rule_cache/dmhc_rule_cache/compute_hash.cc
@@ -21,62 +21,59 @@ void init_hashes() {
   #include "perm7.c"
 }
 
-compute_hash_t::compute_hash_t(int nfields, int *field_widths, 
-                               int k, int capacity) {
+compute_hash_t::compute_hash_t(int nfields, int* field_widths,  int k, int capacity, meta_set_cache_t* cache) {
   //printf("Beginning compute_hash_t\n");
-  int i,h,m,b;
+  ms_cache = cache;
+  int i, h, m, b;
 
 #ifdef INIT_HASH_POSITIONS
-  hash_positions_initialized=false;
-  num_fields=nfields;
-  total_ops_bits=0;
-  for (i=0;i<num_fields;i++)
+  hash_positions_initialized = false;
+  num_fields = nfields;
+  total_ops_bits = 0;
+  for (i = 0;i < num_fields; i++)
     total_ops_bits+=field_widths[i];
 
-  sized_perm=(int **)malloc(sizeof(int *)*k);
-  ops_index=(int *)malloc(sizeof(int)*total_ops_bits);
-  bit_index=(int *)malloc(sizeof(int)*total_ops_bits);
+  sized_perm = (int**)malloc(sizeof(int*)*k);
+  ops_index = (int*)malloc(sizeof(int)*total_ops_bits);
+  bit_index = (int*)malloc(sizeof(int)*total_ops_bits);
   
-  for (h=0;h<k;h++)
-    sized_perm[h]=(int *)malloc(sizeof(int)*total_ops_bits);
+  for (h = 0; h < k; h++)
+    sized_perm[h] = (int*)malloc(sizeof(int)*total_ops_bits);
 
-  for (i=0;i<total_ops_bits;i++) {
-    ops_index[i]=UNASSIGNED;
-    bit_index[i]=UNASSIGNED;
-    for (h=0;h<k;h++)
-      sized_perm[h][i]=UNASSIGNED;
+  for (i = 0; i < total_ops_bits; i++) {
+    ops_index[i] = UNASSIGNED;
+    bit_index[i] = UNASSIGNED;
+    for (h = 0; h < k;h++)
+      sized_perm[h][i] = UNASSIGNED;
   }
   k_hash_position=k;
-  hash_input_position=(int ***)malloc(sizeof(int **)*k);
-  for (h=0;h<k;h++) {
-    hash_input_position[h]=(int **)malloc(sizeof(int *)*num_fields);
-    for (m=0;m<num_fields;m++) {
-      hash_input_position[h][m]=(int *)malloc(sizeof(int)*field_widths[m]);
-      for (b=0;b<field_widths[m];b++)
-        hash_input_position[h][m][b]=UNASSIGNED;
+  hash_input_position = (int***)malloc(sizeof(int**)*k);
+  for (h = 0; h < k; h++) {
+    hash_input_position[h] = (int**)malloc(sizeof(int*)*num_fields);
+    for (m = 0; m < num_fields; m++) {
+      hash_input_position[h][m] = (int*)malloc(sizeof(int)*field_widths[m]);
+      for (b = 0; b < field_widths[m]; b++)
+        hash_input_position[h][m][b] = UNASSIGNED;
     }
   }
 
   // make calls to perform initialization
   // (a) setup arguments/inputs need to make call
-  meta_set_t *dummy_ops=(meta_set_t *)malloc(sizeof(meta_set_t)*num_fields);
-  for (int i=0;i<num_fields;i++){
-    meta_set_t *meta_set = new meta_set_t();
-    meta_set->tags[0]=0;
-    dummy_ops[i]=*meta_set;
+  meta_set_t* dummy_ops = (meta_set_t*)malloc(sizeof(meta_set_t)*num_fields);
+  for (int i = 0; i < num_fields; i++){
+    meta_set_t* meta_set = new meta_set_t();
+    meta_set->tags[0] = 0;
+    dummy_ops[i] = *meta_set;
     delete meta_set;
   }
 
-  int *dummy_hashes=(int *)malloc(sizeof(int)*k);
-
-  bool *dummy_consider=(bool *)malloc(sizeof(bool)*num_fields);
+  int* dummy_hashes = (int*)malloc(sizeof(int)*k);
+  bool* dummy_consider = (bool*)malloc(sizeof(bool)*num_fields);
 
   // (b) call compute_hash for each of the hashes to setup sized_perm and hash_input_position
   // need to call this to get ops_index, bits_index set up
   //printf("Before compute_hash_set\n");
-  compute_hash_set(k, dummy_ops, dummy_hashes, 
-                   num_fields, field_widths,
-                   capacity, dummy_consider);
+  compute_hash_set(k, dummy_ops, dummy_hashes,  num_fields, field_widths, capacity, dummy_consider);
   //printf("After compute_hash_set\n");
 //#ifdef WRITE_VERILOG_HASH
  // verilog_hash(capacity,field_widths);
@@ -84,14 +81,14 @@ compute_hash_t::compute_hash_t(int nfields, int *field_widths,
   free(dummy_consider);
   free(dummy_ops);
   free(dummy_hashes);
-  hash_positions_initialized=true;
+  hash_positions_initialized = true;
 #else
   total_ops_bits=0;
   k_hash_position=0;
-  ops_index=(int *)NULL;
-  bit_index=(int *)NULL;
-  hash_input_position=(int ***)NULL;
-  sized_perm=(int **)NULL;
+  ops_index = (int*)NULL;
+  bit_index = (int*)NULL;
+  hash_input_position = (int***)NULL;
+  sized_perm = (int**)NULL;
 #endif
 
   hash_table.clear();
@@ -104,28 +101,16 @@ compute_hash_t::~compute_hash_t() {
   int h, m;
   free(ops_index);
   free(bit_index);
-  for (h=0;h<k_hash_position;h++)
+  for (h = 0; h < k_hash_position; h++)
     free(sized_perm[h]);
   free(sized_perm);
-  for (h=0;h<k_hash_position;h++) {
-    for (m=0;m<num_fields;m++) {
+  for (h = 0; h < k_hash_position; h++) {
+    for (m = 0; m < num_fields; m++) {
       free(hash_input_position[h][m]);
     }
     free(hash_input_position[h]);
   }
   free(hash_input_position);
-  for (auto entry : hash_table) {
-    delete entry.first.pc;
-    delete entry.first.ci;
-    if (entry.first.op1)
-      delete entry.first.op1;
-    if (entry.first.op2)
-      delete entry.first.op2;
-    if (entry.first.op3)
-      delete entry.first.op3;
-    if (entry.first.mem)
-      delete entry.first.mem;
-  }
   hash_table.clear();
   /**if (static_ops->pc)
     delete static_ops->pc;
@@ -143,182 +128,182 @@ compute_hash_t::~compute_hash_t() {
 }
 
 int min(int a, int b) {
-  if (a<b) return(a); else return(b);
+  if (a < b)
+    return a;
+  else
+    return b;
 }
 
 int log2(int a) {
   int res;
-  for (res=0;(1<<res)<a;res++);
-  return(res);
+  for (res = 0; (1 << res) < a; res++);
+  return res;
 }
 
-int count_ones(int num_fields, int *field_widths, meta_set_t *fields) {
-  int cnt=0;
-  for (int i=0;i<num_fields;i++)
-    for (int j=0;j<field_widths[i];j++)
-      if (((fields->tags[i]>>j) & 0x01)==1)
+int count_ones(int num_fields, int* field_widths, meta_set_t* fields) {
+  int cnt = 0;
+  for (int i = 0; i < num_fields; i++)
+    for (int j = 0; j < field_widths[i]; j++)
+      if (((fields->tags[i] >> j) & 0x01) == 1)
     cnt++;
-  return(cnt);
+  return cnt;
 }
 // Potentially use consider to change result
-int compute_hash_t::compute_hash_from_precomputed_positions(int which, meta_set_t *ops, bool *consider) {
-  int result=0;
+int compute_hash_t::compute_hash_from_precomputed_positions(int which, meta_set_t* ops, bool* consider) {
+  int result = 0;
   int i;
   int val;
-  for (i=0;i<total_ops_bits;i++) {
-    val=((ops[ops_index[i]].tags[0])>>bit_index[i]) & 0x01;
-    int pos=hash_input_position[which][ops_index[i]][bit_index[i]];
-    result=result^(val<<pos);
+  for (i = 0; i < total_ops_bits; i++) {
+    val = ((ops[ops_index[i]].tags[0]) >> bit_index[i]) & 0x01;
+    int pos = hash_input_position[which][ops_index[i]][bit_index[i]];
+    result=result^(val << pos);
   }
-  return(result);
+  return result;
 }
 
-void compute_hash_t::compute_hash_set_from_precomputed_positions(int k, meta_set_t *ops, int *hashes, bool *consider) {
+void compute_hash_t::compute_hash_set_from_precomputed_positions(int k, meta_set_t* ops, int* hashes, bool* consider) {
   int h;
 
 #ifdef HASH_HASH
-  operands_t *static_ops=new operands_t();
-  static_ops->pc=new meta_set_t{OP_PC};
-  static_ops->ci=new meta_set_t{OP_CI};
+  operands_t* static_ops = new operands_t();
+  static_ops->pc = ms_cache->canonize(meta_set_t{OP_PC});
+  static_ops->ci = ms_cache->canonize(meta_set_t{OP_CI});
   if (consider[OP_OP1]) 
-    static_ops->op1=new meta_set_t{ops[OP_OP1]};
+    static_ops->op1 = ms_cache->canonize(meta_set_t{ops[OP_OP1]});
   if (consider[OP_OP2])
-    static_ops->op2=new meta_set_t{ops[OP_OP2]};
+    static_ops->op2 = ms_cache->canonize(meta_set_t{ops[OP_OP2]});
   if (consider[OP_OP3])
-    static_ops->op3=new meta_set_t{ops[OP_OP3]};
+    static_ops->op3 = ms_cache->canonize(meta_set_t{ops[OP_OP3]});
   if (consider[OP_MEM])
-    static_ops->mem=new meta_set_t{ops[OP_MEM]};
+    static_ops->mem = ms_cache->canonize(meta_set_t{ops[OP_MEM]});
 
   auto entries = hash_table.find(*static_ops);
-  if (entries==hash_table.end()) {
+  if (entries == hash_table.end()) {
     std::vector<int> new_h(k_hash_position);
-    for (h=0;h<k_hash_position;h++) {
-      hashes[h]=compute_hash_from_precomputed_positions(h,ops,consider);
-      new_h[h]=hashes[h];
+    for (h = 0; h < k_hash_position; h++) {
+      hashes[h] = compute_hash_from_precomputed_positions(h, ops, consider);
+      new_h[h] = hashes[h];
     }
-    operands_t *new_ops=new operands_t();
-    new_ops->pc=static_ops->pc;
-    new_ops->ci=static_ops->ci;
+    operands_t* new_ops = new operands_t();
+    new_ops->pc = static_ops->pc;
+    new_ops->ci = static_ops->ci;
     if (static_ops->op1)
-      new_ops->op1=static_ops->op1;
+      new_ops->op1 = static_ops->op1;
     if (static_ops->op2)
-      new_ops->op2=static_ops->op2;
+      new_ops->op2 = static_ops->op2;
     if (static_ops->op3)
-      new_ops->op3=static_ops->op3;
+      new_ops->op3 = static_ops->op3;
     if (static_ops->mem)
-      new_ops->mem=static_ops->mem;
-    hash_table.insert({*new_ops,new_h});
+      new_ops->mem = static_ops->mem;
+    hash_table.insert({*new_ops, new_h});
     delete new_ops;
   } else {
-    std::vector<int> result=entries->second;
-    for (h=0;h<k_hash_position;h++)
-      hashes[h]=result.at(h);
+    std::vector<int> result = entries->second;
+    for (h = 0; h < k_hash_position; h++)
+      hashes[h] = result.at(h);
   }
   delete static_ops;
 #else
-  for (h=0;h<k_hash_position;h++)
-    hashes[h]=compute_hash_from_precomputed_positions(h,ops,consider);
+  for (h = 0; h < k_hash_position; h++)
+    hashes[h] = compute_hash_from_precomputed_positions(h, ops, consider);
 #endif
 }
 
-int compute_hash_t::fold(int num_fields, int *field_widths, meta_set_t *fields, int hash_table_size) {
-  int width=log2(hash_table_size);
-  int result=0;
-  int final_pos=0;
-  int field=0;
-  int chunk=0;
+int compute_hash_t::fold(int num_fields, int* field_widths, meta_set_t* fields, int hash_table_size) {
+  int width = log2(hash_table_size);
+  int result = 0;
+  int final_pos = 0;
+  int field = 0;
+  int chunk = 0;
 
-  for (field=0;field<num_fields;field++) {
-    int field_pos=0;
-    while (field_pos<field_widths[field]) {
-      int bits=min((field_widths[field]-field_pos), (width-final_pos));
-      int tmp=(((fields[field].tags[0])>>field_pos) & ((1<<bits) -1))<<final_pos;
-      chunk^=tmp;
+  for (field = 0; field < num_fields; field++) {
+    int field_pos = 0;
+    while (field_pos < field_widths[field]) {
+      int bits = min((field_widths[field] - field_pos), (width - final_pos));
+      int tmp=  (((fields[field].tags[0]) >> field_pos) & ((1 << bits) - 1)) << final_pos;
+      chunk ^= tmp;
 
 #ifdef INIT_HASH_POSITIONS
       int h;
-      if (hash_positions_initialized==false) {
-        for (h=0;h<k_hash_position;h++) {
-          int p=sized_perm[h][field]; 
-          if (p>=0) // gets called for some h's before sized_perm defined
-            hash_input_position[h][ops_index[p]][bit_index[p]]=final_pos;
+      if (hash_positions_initialized == false) {
+        for (h = 0; h < k_hash_position; h++) {
+          int p = sized_perm[h][field]; 
+          if (p >= 0) // gets called for some h's before sized_perm defined
+            hash_input_position[h][ops_index[p]][bit_index[p]] = final_pos;
         }
       }
 #endif      
-      field_pos+=bits;
-      final_pos+=bits;
-      if (final_pos>=width) {
-        result^=chunk;
-        final_pos=0;
-        chunk=0;
+      field_pos += bits;
+      final_pos += bits;
+      if (final_pos >= width) {
+        result ^= chunk;
+        final_pos = 0;
+        chunk = 0;
       }
     }
       // field++ occurs here when field_pos gets to field_widths[field]
   }
-  if (final_pos>0) {
-    result^=chunk; // final chunk
+  if (final_pos > 0) {
+    result ^= chunk; // final chunk
   }
   return result; 
 }
 
 meta_set_t bitrev(int len, meta_set_t a) {
-  meta_set_t *result= new meta_set_t();
-  result->tags[0]=0;
-
-  for (int i=0;i<len;i++) {
-      int bit = (a.tags[0]>>i) % 2;
-      result->tags[0] |= (bit<<(len-i-1));
+  meta_set_t* result = new meta_set_t();
+  result->tags[0] = 0;
+  for (int i = 0; i < len; i++) {
+      int bit = (a.tags[0] >> i) % 2;
+      result->tags[0] |= (bit << (len - i - 1));
   }
   return *result;
 }
 
-void compute_hash_t::convert_to_bit_fields(int orig_num_fields, int *orig_field_widths, meta_set_t *orig_fields,
-                                           int *field_widths, meta_set_t *fields, bool *consider) {
-  int current=0;
-  for (int i=0;i<orig_num_fields;i++) {
-    for (int j=0;j<orig_field_widths[i];j++) {
-      field_widths[current]=1;
-      fields[current].tags[0]=(((orig_fields[i].tags[0])>>j) & 0x01);
+void compute_hash_t::convert_to_bit_fields(int orig_num_fields, int* orig_field_widths, meta_set_t* orig_fields, int* field_widths, meta_set_t* fields, bool* consider) {
+  int current = 0;
+  for (int i = 0; i < orig_num_fields; i++) {
+    for (int j = 0; j < orig_field_widths[i]; j++) {
+      field_widths[current] = 1;
+      fields[current].tags[0] = (((orig_fields[i].tags[0]) >> j) & 0x01);
 #ifdef INIT_HASH_POSITIONS
-      ops_index[current]=i;
-      bit_index[current]=j;
+      ops_index[current] = i;
+      bit_index[current] = j;
 #endif
       current++;
     }
   }
 }
 
-void compute_hash_t::compute_hash_set(int k, meta_set_t *ops, int *hashes, int num_fields, 
-                                      int *field_widths, int capacity, bool *consider) {
-  int ones=0;
-  int bits=0;
-  for (int i=0;i<num_fields;i++)
-    bits+=field_widths[i];
+void compute_hash_t::compute_hash_set(int k, meta_set_t* ops, int* hashes, int num_fields, int* field_widths, int capacity, bool* consider) {
+  int ones = 0;
+  int bits = 0;
+  for (int i = 0; i < num_fields; i++)
+    bits += field_widths[i];
 
   // convert to long bit vector
-  int *bit_field_widths=(int *)malloc(sizeof(int)*(bits));
-  meta_set_t *bit_fields=(meta_set_t *)malloc(sizeof(meta_set_t)*(bits));
-  for (int i=0;i<bits;i++) {
-    meta_set_t *meta_set = new meta_set_t();
-    meta_set->tags[0]=0;
-    bit_fields[i]=*meta_set;
+  int* bit_field_widths = (int*)malloc(sizeof(int)*(bits));
+  meta_set_t* bit_fields = (meta_set_t*)malloc(sizeof(meta_set_t)*(bits));
+  for (int i = 0; i < bits; i++) {
+    meta_set_t* meta_set = new meta_set_t();
+    meta_set->tags[0] = 0;
+    bit_fields[i] = *meta_set;
     delete meta_set;
   }
-  int bit_num_fields=bits;
-  convert_to_bit_fields(num_fields,field_widths,ops,bit_field_widths,bit_fields,consider);
-  meta_set_t *permute_bit_fields=(meta_set_t *)malloc(sizeof(meta_set_t)*(bits));
-  for (int i=0;i<bits;i++) {
-    meta_set_t *meta_set = new meta_set_t();
-    meta_set->tags[0]=0;
-    permute_bit_fields[i]=*meta_set;
+  int bit_num_fields = bits;
+  convert_to_bit_fields(num_fields, field_widths, ops, bit_field_widths, bit_fields, consider);
+  meta_set_t* permute_bit_fields = (meta_set_t*)malloc(sizeof(meta_set_t)*(bits));
+  for (int i = 0; i < bits; i++) {
+    meta_set_t* meta_set = new meta_set_t();
+    meta_set->tags[0] = 0;
+    permute_bit_fields[i] = *meta_set;
     delete meta_set;
   }
 
-  for (int i=0;i<k;i++) {
+  for (int i = 0; i < k; i++) {
       //int tmp=compute_hash(i,bit_num_fields,bit_field_widths,bit_fields,capacity);
       //fprintf(stderr,"returned from compute_hashes with %x\n",tmp); fflush(stderr); // serious debug
       //fprintf(stderr," (attempt to read old value hashes[%d]=%x)\n",i,hashes[i]);
-      hashes[i]=compute_hash((i+HASH_BASE),bit_num_fields,bit_field_widths,bit_fields,permute_bit_fields,capacity,ones);
+      hashes[i] = compute_hash((i + HASH_BASE), bit_num_fields, bit_field_widths, bit_fields, permute_bit_fields, capacity, ones);
       //fprintf(stderr,"hash[%d]=%x\n",i,hashes[i]); fflush(stderr); // serious debug
   }
   
@@ -327,69 +312,68 @@ void compute_hash_t::compute_hash_set(int k, meta_set_t *ops, int *hashes, int n
   free(permute_bit_fields);
 }
 
-int compute_hash_t::compute_hash(int which, int num_fields, int *field_widths, meta_set_t *fields,
-         meta_set_t *permute_fields, int hash_table_size, int ones_cnt) {
+int compute_hash_t::compute_hash(int which, int num_fields, int* field_widths, meta_set_t* fields, meta_set_t* permute_fields, int hash_table_size, int ones_cnt) {
   if (which==0) {// bit reverse entire thing
     // reverse fields
-    for (int i=0;i<(num_fields/2);i++) {
-      int tmp_field=fields[i].tags[0];
-      permute_fields[i].tags[0]=fields[num_fields-i-1].tags[0];
-      permute_fields[num_fields-i-1].tags[0]=tmp_field;
+    for (int i = 0; i < (num_fields/2); i++) {
+      int tmp_field = fields[i].tags[0];
+      permute_fields[i].tags[0] = fields[num_fields - i - 1].tags[0];
+      permute_fields[num_fields - i - 1].tags[0] = tmp_field;
     }
-    if (num_fields%2==1) // 
-      permute_fields[(num_fields)/2].tags[0]=fields[(num_fields)/2].tags[0];
-  } else if (which==1) { // bit pairwise swap
-    for (int i=0;(i+1)<num_fields;i+=2) {
-      int vi=fields[i].tags[0];
-      int vip=fields[i+1].tags[0];
-      permute_fields[i].tags[0]=vip;
-      permute_fields[i+1].tags[0]=vi;
+    if (num_fields % 2 == 1) // 
+      permute_fields[(num_fields)/2].tags[0] = fields[(num_fields)/2].tags[0];
+  } else if (which == 1) { // bit pairwise swap
+    for (int i = 0; (i + 1) < num_fields; i += 2) {
+      int vi = fields[i].tags[0];
+      int vip = fields[i+1].tags[0];
+      permute_fields[i].tags[0] = vip;
+      permute_fields[i+1].tags[0] = vi;
     }
-    if (num_fields%2==1) 
-      permute_fields[num_fields-1].tags[0]=fields[num_fields-1].tags[0];
-  } else if (which==2) { // swap halves
-    int split=num_fields/2;
-    if (num_fields%2==0) {
-      for (int i=0;i<split;i++) {
-        int lo=fields[i].tags[0];
-        int hi=fields[i+split].tags[0];
-        permute_fields[i].tags[0]=hi;
-        permute_fields[i+split].tags[0]=lo;
+    if (num_fields % 2 == 1) 
+      permute_fields[num_fields - 1].tags[0] = fields[num_fields - 1].tags[0];
+  } else if (which == 2) { // swap halves
+    int split = num_fields/2;
+    if (num_fields % 2 == 0) {
+      for (int i = 0; i < split; i++) {
+        int lo = fields[i].tags[0];
+        int hi = fields[i + split].tags[0];
+        permute_fields[i].tags[0] = hi;
+        permute_fields[i + split].tags[0] = lo;
       }
-      permute_fields[split].tags[0]=permute_fields[split<<1].tags[0];
+      permute_fields[split].tags[0] = permute_fields[split << 1].tags[0];
     } else { // odd case (very odd)
-      int top=fields[split].tags[0];
-      for(int i=0;i<split;i++) {
-        permute_fields[i+split].tags[0]=fields[i].tags[0];
-        permute_fields[i].tags[0]=fields[i+split+1].tags[0];
+      int top = fields[split].tags[0];
+      for(int i = 0; i < split; i++) {
+        permute_fields[i + split].tags[0] = fields[i].tags[0];
+        permute_fields[i].tags[0] = fields[i + split + 1].tags[0];
       }
-      permute_fields[split<<1].tags[0]=fields[split].tags[0];
-      permute_fields[num_fields-1].tags[0]=top;
+      permute_fields[split << 1].tags[0] = fields[split].tags[0];
+      permute_fields[num_fields - 1].tags[0] = top;
     }
-  } else if (which==3) { // looks like one is reversed and other isn't
-    int reverse_index=num_fields-1;
-    if ((num_fields%2)==1) {
-      reverse_index=num_fields-2;
-      for (int i=0;i<reverse_index/2;i+=2) {
-        int vi=fields[i].tags[0];
-        int vip=fields[i+1].tags[0];
-        int vri=fields[reverse_index-i].tags[0];
-        int vrip=fields[reverse_index-(i+1)].tags[0];
+  } else if (which == 3) { // looks like one is reversed and other isn't
+    int reverse_index = num_fields - 1;
+    if ((num_fields % 2) == 1) {
+      reverse_index = num_fields - 2;
+      for (int i = 0; i < reverse_index/2; i += 2) {
+        int vi = fields[i].tags[0];
+        int vip = fields[i + 1].tags[0];
+        int vri = fields[reverse_index - i].tags[0];
+        int vrip = fields[reverse_index - (i + 1)].tags[0];
 
         // 0 and 1 differ only in assignments we make here
-        permute_fields[i].tags[0]=vri;
-        permute_fields[i+1].tags[0]=vi;
-        permute_fields[reverse_index-i].tags[0]=vrip;
-        permute_fields[reverse_index-(i+1)].tags[0]=vip;
+        permute_fields[i].tags[0] = vri;
+        permute_fields[i + 1].tags[0] = vi;
+        permute_fields[reverse_index - i].tags[0] = vrip;
+        permute_fields[reverse_index - (i + 1)].tags[0] = vip;
       }
-      if ((reverse_index/4)%2==1) { // blah, hate to special case, but appears to be missed by above
-        int vi=fields[reverse_index/2].tags[0];
-        int vip=fields[reverse_index/2+1].tags[0];
-        permute_fields[reverse_index/2].tags[0]=vip;
-        permute_fields[reverse_index/2+1].tags[0]=vi;
+      if ((reverse_index/4) % 2 == 1) { // blah, hate to special case, but appears to be missed by above
+        int vi = fields[reverse_index/2].tags[0];
+        int vip = fields[reverse_index/2 + 1].tags[0];
+        permute_fields[reverse_index/2].tags[0] = vip;
+        permute_fields[reverse_index/2 + 1].tags[0] = vi;
       }
-      if (num_fields%2==1) 
-        permute_fields[num_fields-1].tags[0]=fields[num_fields-1].tags[0];
+      if (num_fields % 2 == 1) 
+        permute_fields[num_fields - 1].tags[0] = fields[num_fields - 1].tags[0];
     }
   }
   //  else if (which==4) // noop
@@ -399,24 +383,24 @@ int compute_hash_t::compute_hash(int which, int num_fields, int *field_widths, m
   //      for (int i=0;i<num_fields;i++)
   //    permute_fields[i]=fields[i];
   //}
-  else if (which<8) {
-    int *perm;
-    if (which==4)
+  else if (which < 8) {
+    int* perm;
+    if (which == 4)
       //perm=perm47324;
-      perm=perm4;
-    else if (which==5)
-      perm=perm5172;
-    else if (which==6)
-      perm=perm6237886;
-    else if (which==7)
-      perm=perm7128386; 
-    for (int i=0;i<num_fields;i++) {
-      int tmp=perm[i];
-      while (tmp>=num_fields) tmp=perm[tmp];
-      permute_fields[i].tags[0]=fields[tmp].tags[0];
+      perm = perm4;
+    else if (which == 5)
+      perm = perm5172;
+    else if (which == 6)
+      perm = perm6237886;
+    else if (which == 7)
+      perm = perm7128386; 
+    for (int i = 0; i < num_fields; i++) {
+      int tmp = perm[i];
+      while (tmp >= num_fields) tmp = perm[tmp];
+      permute_fields[i].tags[0] = fields[tmp].tags[0];
 #ifdef INIT_HASH_POSITIONS
       if (!hash_positions_initialized) {
-        sized_perm[which-HASH_BASE][i]=tmp; // original
+        sized_perm[which-HASH_BASE][i] = tmp; // original
       }
 #endif
     }
@@ -426,9 +410,9 @@ int compute_hash_t::compute_hash(int which, int num_fields, int *field_widths, m
       exit(1);
   }  
 
-  int result=fold(num_fields,field_widths,permute_fields,hash_table_size);
+  int result = fold(num_fields, field_widths, permute_fields, hash_table_size);
 
-  return(result);
+  return result;
 }
 
 } // namespace policy_engine

--- a/validator/rule_cache/dmhc_rule_cache/compute_hash.h
+++ b/validator/rule_cache/dmhc_rule_cache/compute_hash.h
@@ -34,18 +34,16 @@ void init_hashes();
 class compute_hash_t {
 
  public:
-  compute_hash_t(int num_fields, int* field_widths,  int k, int capacity, meta_set_cache_t* cache);
+  compute_hash_t(int num_fields, int* field_widths,  int k, int capacity);
   ~compute_hash_t();
-  void compute_hash_set_from_precomputed_positions(int k, meta_set_t* ops, int* hashes, bool* consider);
-  void compute_hash_set(int k, meta_set_t* ops, int* hashes, int num_fields,  int* field_widths, int capacity, bool* consider);
+  void compute_hash_set_from_precomputed_positions(int k, const operands_t& ops, int* hashes, bool* consider);
+  void compute_hash_set(int k, const operands_t& ops, int* hashes, int num_fields, int* field_widths, int capacity, bool* consider);
 
  private:
-  int compute_hash_from_precomputed_positions(int which, meta_set_t* ops, bool* consider);
-  int compute_hash(int which, int num_fields, int* field_widths, meta_set_t* fields,  meta_set_t* permute_field, int hash_table_size, int ones_cnt);
+  int compute_hash_from_precomputed_positions(int which, const operands_t& ops, bool* consider);
+  int compute_hash(int which, int num_fields, int* field_widths, meta_set_t* fields, meta_set_t* permute_field, int hash_table_size, int ones_cnt);
   int fold(int num_fields, int* field_widths, meta_set_t* fields, int hash_table_size);
-  void convert_to_bit_fields(int orig_num_fields, int* orig_field_widths,  meta_set_t* orig_fields, int* field_widths,  meta_set_t* fields, bool* consider);
-
-  meta_set_cache_t* ms_cache;
+  void convert_to_bit_fields(int orig_num_fields, int* orig_field_widths, const meta_set_t* orig_fields, int* field_widths, meta_set_t* fields, bool* consider);
 
   int num_fields;
   int* ops_index;

--- a/validator/rule_cache/dmhc_rule_cache/compute_hash.h
+++ b/validator/rule_cache/dmhc_rule_cache/compute_hash.h
@@ -1,6 +1,16 @@
 #ifndef _COMPUTE_HASH_H
 #define _COMPUTE_HASH_H
 
+#include <cinttypes>
+#include <unordered_map>
+#include <vector>
+#include "meta_cache.h"
+#include "riscv_isa.h"
+
+//#define INIT_HASH_POSITIONS 1
+#define HASH_HASH 1
+//#define DMHC_DEBUG 1
+
 #define OP_PC 0
 #define OP_CI 1
 #define OP_OP1 2
@@ -17,57 +27,14 @@
 #define RES_LEN 6
 #define BOOL_WIDTH 8
 
-#include <map>
-#include <vector>
-#include "riscv_isa.h"
-#include <inttypes.h>
-//#define INIT_HASH_POSITIONS 1
-#define HASH_HASH 1
-//#define DMHC_DEBUG 1
-
 namespace policy_engine {
 
 void init_hashes();
 
-struct compare_op {
-  bool operator()(const operands_t& a, const operands_t& b) const {
-    if (a.op1 && !b.op1) return false;
-    if (b.op1 && !a.op1) return false;
-    if (a.op2 && !b.op2) return false;
-    if (b.op2 && !a.op2) return false;
-    if (a.op3 && !b.op3) return false;
-    if (b.op3 && !a.op3) return false;
-    if (a.mem && !b.mem) return false;
-    if (b.mem && !a.mem) return false;
-
-    if (a.op1 && b.op1) {
-      if (a.op1->tags[0] != b.op1->tags[0])
-        return false;
-    }
-    if (a.op2 && b.op2) {
-      if (a.op2->tags[0] != b.op2->tags[0])
-        return false;
-    }
-    if (a.op3 && b.op3) {
-      if (a.op3->tags[0] != b.op3->tags[0])
-        return false;
-    }
-    if (a.mem && b.mem) {
-      if (a.mem->tags[0] != b.mem->tags[0])
-        return false;
-    }
-    if ((a.pc->tags[0] == b.pc->tags[0]) && 
-        (a.ci->tags[0] == b.ci->tags[0]))
-      return true;
-
-    return false;
-  }
-};
-
 class compute_hash_t {
 
  public:
-  compute_hash_t(int num_fields, int* field_widths,  int k, int capacity);
+  compute_hash_t(int num_fields, int* field_widths,  int k, int capacity, meta_set_cache_t* cache);
   ~compute_hash_t();
   void compute_hash_set_from_precomputed_positions(int k, meta_set_t* ops, int* hashes, bool* consider);
   void compute_hash_set(int k, meta_set_t* ops, int* hashes, int num_fields,  int* field_widths, int capacity, bool* consider);
@@ -78,6 +45,8 @@ class compute_hash_t {
   int fold(int num_fields, int* field_widths, meta_set_t* fields, int hash_table_size);
   void convert_to_bit_fields(int orig_num_fields, int* orig_field_widths,  meta_set_t* orig_fields, int* field_widths,  meta_set_t* fields, bool* consider);
 
+  meta_set_cache_t* ms_cache;
+
   int num_fields;
   int* ops_index;
   int* bit_index;
@@ -87,7 +56,7 @@ class compute_hash_t {
   int total_ops_bits;
   bool hash_positions_initialized;
   //operands_t *static_ops;
-  std::map<operands_t, std::vector<int>, struct compare_op> hash_table;
+  std::unordered_map<operands_t, std::vector<int>> hash_table;
 };
 
 } // namespace policy_engine

--- a/validator/rule_cache/dmhc_rule_cache/compute_hash.h
+++ b/validator/rule_cache/dmhc_rule_cache/compute_hash.h
@@ -30,7 +30,7 @@ namespace policy_engine {
 void init_hashes();
 
 struct compare_op {
-  bool operator()(const operands_t &a, const operands_t &b) const {
+  bool operator()(const operands_t& a, const operands_t& b) const {
     if (a.op1 && !b.op1) return false;
     if (b.op1 && !a.op1) return false;
     if (a.op2 && !b.op2) return false;
@@ -41,23 +41,23 @@ struct compare_op {
     if (b.mem && !a.mem) return false;
 
     if (a.op1 && b.op1) {
-      if (a.op1->tags[0]!=b.op1->tags[0])
+      if (a.op1->tags[0] != b.op1->tags[0])
         return false;
     }
     if (a.op2 && b.op2) {
-      if (a.op2->tags[0]!=b.op2->tags[0])
+      if (a.op2->tags[0] != b.op2->tags[0])
         return false;
     }
     if (a.op3 && b.op3) {
-      if (a.op3->tags[0]!=b.op3->tags[0])
+      if (a.op3->tags[0] != b.op3->tags[0])
         return false;
     }
     if (a.mem && b.mem) {
-      if (a.mem->tags[0]!=b.mem->tags[0])
+      if (a.mem->tags[0] != b.mem->tags[0])
         return false;
     }
-    if ((a.pc->tags[0]==b.pc->tags[0]) && 
-        (a.ci->tags[0]==b.ci->tags[0]))
+    if ((a.pc->tags[0] == b.pc->tags[0]) && 
+        (a.ci->tags[0] == b.ci->tags[0]))
       return true;
 
     return false;
@@ -67,27 +67,22 @@ struct compare_op {
 class compute_hash_t {
 
  public:
-  compute_hash_t(int num_fields, int *field_widths, 
-	         int k, int capacity);
+  compute_hash_t(int num_fields, int* field_widths,  int k, int capacity);
   ~compute_hash_t();
-  void compute_hash_set_from_precomputed_positions(int k, meta_set_t *ops, int *hashes, bool *consider);
-  void compute_hash_set(int k, meta_set_t *ops, int *hashes, int num_fields, 
-                        int *field_widths, int capacity, bool *consider);
+  void compute_hash_set_from_precomputed_positions(int k, meta_set_t* ops, int* hashes, bool* consider);
+  void compute_hash_set(int k, meta_set_t* ops, int* hashes, int num_fields,  int* field_widths, int capacity, bool* consider);
 
  private:
-  int compute_hash_from_precomputed_positions(int which, meta_set_t *ops, bool *consider);
-  int compute_hash(int which, int num_fields, int *field_widths, meta_set_t *fields, 
-                   meta_set_t *permute_field, int hash_table_size, int ones_cnt);
-  int fold(int num_fields, int *field_widths, meta_set_t *fields, int hash_table_size);
-  void convert_to_bit_fields(int orig_num_fields, int *orig_field_widths, 
-			     meta_set_t *orig_fields, int *field_widths, 
-			     meta_set_t *fields, bool *consider);
+  int compute_hash_from_precomputed_positions(int which, meta_set_t* ops, bool* consider);
+  int compute_hash(int which, int num_fields, int* field_widths, meta_set_t* fields,  meta_set_t* permute_field, int hash_table_size, int ones_cnt);
+  int fold(int num_fields, int* field_widths, meta_set_t* fields, int hash_table_size);
+  void convert_to_bit_fields(int orig_num_fields, int* orig_field_widths,  meta_set_t* orig_fields, int* field_widths,  meta_set_t* fields, bool* consider);
 
   int num_fields;
-  int * ops_index;
-  int * bit_index;
-  int ***hash_input_position;
-  int ** sized_perm;
+  int* ops_index;
+  int* bit_index;
+  int*** hash_input_position;
+  int** sized_perm;
   int k_hash_position;
   int total_ops_bits;
   bool hash_positions_initialized;

--- a/validator/rule_cache/dmhc_rule_cache/dmhc.cc
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc.cc
@@ -1,97 +1,96 @@
 #include <cassert>
 #include "dmhc.h"
+#include "meta_cache.h"
 #include "tag_utils.h"
 
 namespace policy_engine {
 
-dmhc_t::dmhc_t(int cap, int newk, int newc, int infields, int outfields, int *ops_size, 
-         int *res_size, bool new_no_evict) {
-  k=newk;
-  c=newc;
-  input_fields=infields;
-  output_fields=outfields;
-  capacity=cap;
-  no_evict=new_no_evict;
+dmhc_t::dmhc_t(int cap, int newk, int newc, int infields, int outfields, int* ops_size,  int* res_size, bool new_no_evict, meta_set_cache_t* ms_cache) {
+  k = newk;
+  c = newc;
+  input_fields = infields;
+  output_fields = outfields;
+  capacity = cap;
+  no_evict = new_no_evict;
 
-  assert(capacity>1); // capacity 1 case doesn't work since we use the 
-                      //0 entry for INVALID_LAST_USER
+  assert(capacity > 1); // capacity 1 case doesn't work since we use the 
+                        //0 entry for INVALID_LAST_USER
 
-  hashes=(int *)malloc(sizeof(int)*k);
-  victim_hashes=(int *)malloc(sizeof(int)*k);
-  do_not_victimize_hashes=(int *)malloc(sizeof(int)*k);
-  victim_ops=(meta_set_t *)malloc(sizeof(meta_set_t)*input_fields);
-  victim_res=(meta_set_t *)malloc(sizeof(meta_set_t)*output_fields);
-  reinsert_ops=(meta_set_t *)malloc(sizeof(meta_set_t)*input_fields);
-  reinsert_res=(meta_set_t *)malloc(sizeof(meta_set_t)*output_fields);
-  consider_evict=(bool *)malloc(sizeof(bool)*input_fields);
+  hashes = (int*)malloc(sizeof(int)*k);
+  victim_hashes = (int*)malloc(sizeof(int)*k);
+  do_not_victimize_hashes = (int*)malloc(sizeof(int)*k);
+  victim_ops = (meta_set_t*)malloc(sizeof(meta_set_t)*input_fields);
+  victim_res = (meta_set_t*)malloc(sizeof(meta_set_t)*output_fields);
+  reinsert_ops = (meta_set_t*)malloc(sizeof(meta_set_t)*input_fields);
+  reinsert_res = (meta_set_t*)malloc(sizeof(meta_set_t)*output_fields);
+  consider_evict = (bool*)malloc(sizeof(bool)*input_fields);
 
   // store fields
-  input_field_widths=(int *)malloc(sizeof(int)*input_fields);
-  output_field_widths=(int *)malloc(sizeof(int)*output_fields);
-  for (int i=0;i<input_fields;i++)
-    input_field_widths[i]=ops_size[i];
-  for (int i=0;i<output_fields;i++)
-    output_field_widths[i]=res_size[i];
+  input_field_widths = (int*)malloc(sizeof(int)*input_fields);
+  output_field_widths = (int*)malloc(sizeof(int)*output_fields);
+  for (int i = 0; i < input_fields; i++)
+    input_field_widths[i] = ops_size[i];
+  for (int i = 0; i < output_fields; i++)
+    output_field_widths[i] = res_size[i];
 
   // initialize tables
-  gtable=(int **)malloc(sizeof(int *)*k);
-  gtable_cnt=(int **)malloc(sizeof(int *)*k);
-  gtable_lastinsert=(int **)malloc(sizeof(int *)*k);
-  for (int i=0;i<k;i++) {
-    gtable[i]=(int *)malloc(sizeof(int)*c*capacity);
-    gtable_cnt[i]=(int *)malloc(sizeof(int)*c*capacity);
-    gtable_lastinsert[i]=(int *)malloc(sizeof(int)*c*capacity);
+  gtable = (int**)malloc(sizeof(int *)*k);
+  gtable_cnt = (int**)malloc(sizeof(int *)*k);
+  gtable_lastinsert = (int**)malloc(sizeof(int *)*k);
+  for (int i = 0; i < k; i++) {
+    gtable[i] = (int*)malloc(sizeof(int)*c*capacity);
+    gtable_cnt[i] = (int*)malloc(sizeof(int)*c*capacity);
+    gtable_lastinsert[i] = (int*)malloc(sizeof(int)*c*capacity);
   }
     
-  mtable_use=(bool *)malloc(sizeof(bool)*capacity);
-  mtable_inputs=(meta_set_t **)malloc(sizeof(meta_set_t *)*input_fields);
-  for (int i=0;i<input_fields;i++) {
-    mtable_inputs[i]=(meta_set_t *)malloc(sizeof(meta_set_t)*capacity);
+  mtable_use = (bool*)malloc(sizeof(bool)*capacity);
+  mtable_inputs = (meta_set_t**)malloc(sizeof(meta_set_t *)*input_fields);
+  for (int i = 0; i < input_fields; i++) {
+    mtable_inputs[i] = (meta_set_t*)malloc(sizeof(meta_set_t)*capacity);
   }
-  mtable_outputs=(meta_set_t **)malloc(sizeof(meta_set_t *)*output_fields);
-  for (int i=0;i<output_fields;i++) {
-    mtable_outputs[i]=(meta_set_t *)malloc(sizeof(meta_set_t)*capacity);
+  mtable_outputs = (meta_set_t**)malloc(sizeof(meta_set_t *)*output_fields);
+  for (int i = 0; i < output_fields; i++) {
+    mtable_outputs[i] = (meta_set_t*)malloc(sizeof(meta_set_t)*capacity);
   }
-  consider_mtable_input=(bool **)malloc(sizeof(bool *)*input_fields);
-  for (int i=0;i<input_fields;i++) {
-    consider_mtable_input[i]=(bool *)malloc(sizeof(bool)*capacity);
+  consider_mtable_input = (bool**)malloc(sizeof(bool *)*input_fields);
+  for (int i = 0; i < input_fields; i++) {
+    consider_mtable_input[i] = (bool*)malloc(sizeof(bool)*capacity);
   }
 #ifdef DMHC_DIRECT_K_HASH_CONFLICTS 
-  mtable_hashes=(int **)malloc(sizeof(int *)*k);
-  for (int i=0;i<k;i++)
-    mtable_hashes[i]=(int *)malloc(sizeof(int)*capacity);
+  mtable_hashes = (int**)malloc(sizeof(int*)*k);
+  for (int i = 0; i < k; i++)
+    mtable_hashes[i] = (int*)malloc(sizeof(int)*capacity);
 #else
-  mtable_hashes=(int **)NULL;
+  mtable_hashes=(int**)NULL;
 #endif
   
   init_hashes();
 
   // need to call even if INIT_HASH_POSITIONS is false
-  hasher= new compute_hash_t(input_fields,input_field_widths, k, 
-                             c*capacity); // total capacity (so apply c)
+  hasher = new compute_hash_t(input_fields,input_field_widths, k, c*capacity, ms_cache); // total capacity (so apply c)
 
   reset(); // to initialize all the fields
 }
 
 dmhc_t::~dmhc_t() {
-  for (int i=0;i<k;i++) {
+  for (int i = 0; i < k; i++) {
     free(gtable[i]);
     free(gtable_cnt[i]);
     free(gtable_lastinsert[i]);
   }
   free(gtable);
   free(gtable_lastinsert);
-  for (int i=0;i<input_fields;i++)
+  for (int i = 0; i < input_fields; i++)
     free(mtable_inputs[i]);
   free(mtable_inputs);
-  for (int i=0;i<output_fields;i++)
+  for (int i = 0; i < output_fields; i++)
     free(mtable_outputs[i]);
   free(mtable_outputs);
-  for (int i=0;i<input_fields;i++)
+  for (int i = 0; i < input_fields; i++)
     free(consider_mtable_input[i]);
   free(consider_mtable_input);
 #ifdef DMHC_DIRECT_K_HASH_CONFLICTS 
-  for (int i=0;i<k;i++)
+  for (int i = 0; i < k; i++)
     free(mtable_hashes[i]);
 #endif  
   free(input_field_widths);
@@ -109,67 +108,67 @@ dmhc_t::~dmhc_t() {
 }
 
 void dmhc_t::reset() {
-  next_entry=1;  // skip 0 = INVALID_LAST_USER
-  for (int i=0;i<k;i++) {
-    for (int j=0;j<(c*capacity);j++) {
-      gtable[i][j]=0;
-      gtable_cnt[i][j]=0;
-      gtable_lastinsert[i][j]=INVALID_LAST_USER;
+  next_entry = 1;  // skip 0 = INVALID_LAST_USER
+  for (int i = 0; i < k; i++) {
+    for (int j = 0; j < (c*capacity); j++) {
+      gtable[i][j] = 0;
+      gtable_cnt[i][j] = 0;
+      gtable_lastinsert[i][j] = INVALID_LAST_USER;
     }
   }
-  for (int j=0;j<capacity;j++)
-    mtable_use[j]=false;
-  for (int i=0;i<input_fields;i++) {
-    for (int j=0;j<capacity;j++) {
-      meta_set_t *new_input = new meta_set_t();
-      new_input->tags[0]=0;
-      mtable_inputs[i][j]=*new_input;
+  for (int j = 0; j < capacity; j++)
+    mtable_use[j] = false;
+  for (int i = 0; i < input_fields; i++) {
+    for (int j = 0; j < capacity; j++) {
+      meta_set_t* new_input = new meta_set_t();
+      new_input->tags[0] = 0;
+      mtable_inputs[i][j] = *new_input;
       delete new_input;
-      consider_mtable_input[i][j]=false;
+      consider_mtable_input[i][j] = false;
     }
   }
-  for (int i=0;i<output_fields;i++) {
-    for (int j=0;j<capacity;j++) {
-      meta_set_t *new_output = new meta_set_t();
-      new_output->tags[0]=0;
-      mtable_outputs[i][j]=*new_output;
+  for (int i = 0; i < output_fields; i++) {
+    for (int j = 0; j < capacity; j++) {
+      meta_set_t* new_output = new meta_set_t();
+      new_output->tags[0] = 0;
+      mtable_outputs[i][j] = *new_output;
       delete new_output;
     }
   }
 
 #ifdef DMHC_DIRECT_K_HASH_CONFLICTS   
-  for (int i=0;i<k;i++) {
-    for (int j=0;j<capacity;j++)
-      mtable_hashes[i][j]=(int)-1;
+  for (int i = 0; i < k; i++) {
+    for (int j = 0; j < capacity; j++)
+      mtable_hashes[i][j] = -1;
   }
 #endif
   
-  hits=0; misses=0; false_hits=0; direct_conflicts=0; inserts=0;
+  hits = 0; misses = 0; false_hits = 0; direct_conflicts = 0; inserts = 0;
 }
 
-void dmhc_t::check_direct_k_hash_conflicts(meta_set_t *ops, bool *consider) {
-  compute_hashes(ops,hashes,consider);
-  for (int i=0;i<capacity;i++) {
-    if (mtable_use[i]==true) {
-      bool conflict=true;
-      for (int j=0;j<k;j++)
-        if (hashes[j]!=mtable_hashes[j][i])
-          conflict=false;
-      bool real_conflict=false;
+void dmhc_t::check_direct_k_hash_conflicts(meta_set_t* ops, bool* consider) {
+  compute_hashes(ops, hashes, consider);
+  for (int i = 0; i < capacity; i++) {
+    if (mtable_use[i] == true) {
+      bool conflict = true;
+      for (int j = 0; j < k; j++)
+        if (hashes[j] != mtable_hashes[j][i])
+          conflict = false;
+      bool real_conflict = false;
       if (conflict)
-        for (int j=0;j<input_fields;j++)
-          if (ops[j].tags[0]!=mtable_inputs[j][i].tags[0])
-            real_conflict=true;
+        for (int j = 0; j < input_fields; j++)
+          if (ops[j].tags[0] != mtable_inputs[j][i].tags[0])
+            real_conflict = true;
       if (real_conflict) {
         printf("dMHC: (compute ) WARNING direct k-hash conflict ");
-        for (int f=0;f<k;f++)
+        for (int f = 0; f < k; f++)
           printf("%03x ",mtable_hashes[f][i]);
         printf(": [");
-        for (int f=0;f<input_fields;f++)
+        for (int f = 0; f < input_fields; f++)
           printf("%" PRItag " ",ops[f].tags[0]);
         printf("]");
         printf(" [");
-        for (int f=0;f<input_fields;f++)
+        for (int f = 0; f < input_fields; f++)
           printf("%" PRItag " ",mtable_inputs[f][i].tags[0]);
         printf("]\n");
         direct_conflicts++;
@@ -178,29 +177,29 @@ void dmhc_t::check_direct_k_hash_conflicts(meta_set_t *ops, bool *consider) {
   }
 }
   
-void dmhc_t::compute_hashes(meta_set_t *ops, int *hashes_to_fill, bool *consider) {
+void dmhc_t::compute_hashes(meta_set_t* ops, int* hashes_to_fill, bool* consider) {
 #ifdef INIT_HASH_POSITIONS
-  hasher->compute_hash_set_from_precomputed_positions(k,ops,hashes_to_fill,consider);
+  hasher->compute_hash_set_from_precomputed_positions(k, ops, hashes_to_fill, consider);
 #else
-  hasher->compute_hash_set(k,ops,hashes_to_fill,input_fields,input_field_widths,c*capacity,consider);
+  hasher->compute_hash_set(k, ops, hashes_to_fill, input_fields, input_field_widths, c*capacity, consider);
 #endif
 
 #ifdef VERIFY_PRECOMPUTE_HASH
-  int *verify_hashes=(int *)malloc(sizeof(int)*k);
-  hasher->compute_hash_set(k,ops,verify_hashes,input_fields,input_field_widths,c*capacity,consider);
+  int* verify_hashes = (int*)malloc(sizeof(int)*k);
+  hasher->compute_hash_set(k, ops, verify_hashes, input_fields, input_field_widths, c*capacity, consider);
   int h;
-  bool mismatch=false;
-  for (h=0;h<k;h++) {
-    if (verify_hashes[h]!=hashes_to_fill[h])
-      mismatch=true;
+  bool mismatch = false;
+  for (h = 0; h < k; h++) {
+    if (verify_hashes[h] != hashes_to_fill[h])
+      mismatch = true;
   }
   if (mismatch) {
     printf("compute_hashes: VERIFY ERROR ");
-    for (h=0;h<k;h++) 
+    for (h = 0; h < k; h++) 
       printf(" [%x %x]", verify_hashes[h], hashes_to_fill[h]);
     printf(" <-from- ");
-    for (h=0;h<input_fields;h++)
-      printf(" %" PRItag,ops[h].tags[0]);
+    for (h = 0; h < input_fields; h++)
+      printf(" %" PRItag, ops[h].tags[0]);
       printf("\n");
       printf("HALTING ON FAILED VERIFY OF PRECOMPUTED HASH\n");
     exit(37); 
@@ -211,31 +210,31 @@ void dmhc_t::compute_hashes(meta_set_t *ops, int *hashes_to_fill, bool *consider
 #endif
 }
 
-bool dmhc_t::hit(meta_set_t *ops,int address, bool *consider) {
-  if (mtable_use[address]==false) {
+bool dmhc_t::hit(meta_set_t* ops, int address, bool* consider) {
+  if (mtable_use[address] == false) {
     printf("mtable_use[address} is false\n");
-    return(false);
+    return false;
   }
 
-  for (int i=0;i<input_fields;i++) {
+  for (int i = 0; i < input_fields; i++) {
     if (consider[i]) {
-      if (mtable_inputs[i][address].tags[0]!=ops[i].tags[0]) {
+      if (mtable_inputs[i][address].tags[0] != ops[i].tags[0]) {
         printf("mtable_inputs[%d][address] is false\n", i);
-        return(false);
+        return false;
       }
     }
   }
-  return(true);
+  return true;
 }
 
 void dmhc_t::copy_victim_to_reinsert() {
-  for (int i=0;i<input_fields;i++)
-    reinsert_ops[i].tags[0]=victim_ops[i].tags[0];
-  for (int i=0;i<output_fields;i++)
-    reinsert_res[i].tags[0]=victim_res[i].tags[0];
+  for (int i = 0; i < input_fields; i++)
+    reinsert_ops[i].tags[0] = victim_ops[i].tags[0];
+  for (int i = 0; i < output_fields; i++)
+    reinsert_res[i].tags[0] = victim_res[i].tags[0];
 }
 
-void dmhc_t::evict_mtable_entry(int address, meta_set_t* victim_ops, meta_set_t *victim_res, int *do_not_victimize) {
+void dmhc_t::evict_mtable_entry(int address, meta_set_t* victim_ops, meta_set_t* victim_res, int* do_not_victimize) {
 
   int result;
   if (no_evict) {
@@ -243,74 +242,74 @@ void dmhc_t::evict_mtable_entry(int address, meta_set_t* victim_ops, meta_set_t 
   }
   
   //bool consider_evict[input_fields];
-  for (int i=0;i<input_fields;i++) {
-    victim_ops[i].tags[0]=mtable_inputs[i][address].tags[0];
-    mtable_inputs[i][address].tags[0]=0;
-    consider_evict[i]=consider_mtable_input[i][address];
+  for (int i = 0; i < input_fields; i++) {
+    victim_ops[i].tags[0] = mtable_inputs[i][address].tags[0];
+    mtable_inputs[i][address].tags[0] = 0;
+    consider_evict[i] = consider_mtable_input[i][address];
   }
 
-  for (int i=0;i<output_fields;i++)  {
-    victim_res[i].tags[0]=mtable_outputs[i][address].tags[0];
-    mtable_outputs[i][address].tags[0]=0;
+  for (int i = 0; i < output_fields; i++)  {
+    victim_res[i].tags[0] = mtable_outputs[i][address].tags[0];
+    mtable_outputs[i][address].tags[0] = 0;
   }
 
-  mtable_use[address]=false;
-  compute_hashes(victim_ops,victim_hashes,consider_evict);
-  bool cleared_gtable=false;
+  mtable_use[address] = false;
+  compute_hashes(victim_ops, victim_hashes, consider_evict);
+  bool cleared_gtable = false;
 
-  for (int i=0;i<k;i++) {
+  for (int i= 0; i < k; i++) {
     // because something may have gotten bashed and we did *not* know the user
     //   it is possible the mtable entry is an orphan, and the associated gtable entry is gone;
     // ...so, it is possible that this has already been decremented to zero -- catch that...
-    if (gtable_cnt[i][victim_hashes[i]]>0) {
+    if (gtable_cnt[i][victim_hashes[i]] > 0) {
       // because the counts can be wrong, we can have a case where
       //  this would erroneously count down to zero
-      if ((do_not_victimize==(int *)NULL) || (do_not_victimize[i]!=victim_hashes[i])) {
-        gtable_cnt[i][victim_hashes[i]]=gtable_cnt[i][victim_hashes[i]]-1;
+      if ((do_not_victimize == NULL) || (do_not_victimize[i] != victim_hashes[i])) {
+        gtable_cnt[i][victim_hashes[i]] = gtable_cnt[i][victim_hashes[i]] - 1;
       }
       // if it is a do_not_victimize, 
       //   we still want to remove the contribution of the victim,
       //   we just don't want to drop cnt to 1
-      else if ((do_not_victimize!=(int *)NULL) && (do_not_victimize[i]==victim_hashes[i])) {
-    if (gtable_cnt[i][victim_hashes[i]]>1)
-      gtable_cnt[i][victim_hashes[i]]=gtable_cnt[i][victim_hashes[i]]-1;
+      else if ((do_not_victimize != NULL) && (do_not_victimize[i] == victim_hashes[i])) {
+    if (gtable_cnt[i][victim_hashes[i]] > 1)
+      gtable_cnt[i][victim_hashes[i]] = gtable_cnt[i][victim_hashes[i]] - 1;
       }
     }
-    if (gtable_cnt[i][victim_hashes[i]]==0) {
-      cleared_gtable=true;
+    if (gtable_cnt[i][victim_hashes[i]] == 0) {
+      cleared_gtable = true;
       // (originally BSV not do this)
-      gtable[i][victim_hashes[i]]=0; 
-      gtable_lastinsert[i][victim_hashes[i]]=INVALID_LAST_USER;
-    } else if (gtable_lastinsert[i][victim_hashes[i]]==address) {
-      gtable_lastinsert[i][victim_hashes[i]]=INVALID_LAST_USER;
+      gtable[i][victim_hashes[i]] = 0; 
+      gtable_lastinsert[i][victim_hashes[i]] = INVALID_LAST_USER;
+    } else if (gtable_lastinsert[i][victim_hashes[i]] == address) {
+      gtable_lastinsert[i][victim_hashes[i]] = INVALID_LAST_USER;
     }
   }
 }
 
-void dmhc_t::real_insert(int address, meta_set_t *ops, meta_set_t *res, int *hashes, int free_slot, bool *consider) {
-  for (int i=0;i<input_fields;i++) {
-    consider_mtable_input[i][address]=consider[i];
+void dmhc_t::real_insert(int address, meta_set_t* ops, meta_set_t* res, int* hashes, int free_slot, bool* consider) {
+  for (int i = 0; i < input_fields; i++) {
+    consider_mtable_input[i][address] = consider[i];
     if (consider_mtable_input[i][address])
-      mtable_inputs[i][address].tags[0]=ops[i].tags[0];
+      mtable_inputs[i][address].tags[0] = ops[i].tags[0];
   }
-  for (int i=0;i<output_fields;i++)
-    mtable_outputs[i][address].tags[0]=res[i].tags[0];
+  for (int i = 0; i < output_fields; i++)
+    mtable_outputs[i][address].tags[0] = res[i].tags[0];
 #ifdef DMHC_DIRECT_K_HASH_CONFLICTS
-  for (int i=0;i<k;i++)
-    mtable_hashes[i][address]=hashes[i];
+  for (int i = 0; i < k; i++)
+    mtable_hashes[i][address] = hashes[i];
 #endif
-  mtable_use[address]=true;
+  mtable_use[address] = true;
   
-  assert(gtable_cnt[free_slot][hashes[free_slot]]==0); // this should only be called after evicting rules to make space
+  assert(gtable_cnt[free_slot][hashes[free_slot]] == 0); // this should only be called after evicting rules to make space
 
   int current_value=0;
-  for (int i=0;i<k;i++)
-    current_value=current_value^gtable[i][hashes[i]];
+  for (int i = 0; i < k; i++)
+    current_value = current_value^gtable[i][hashes[i]];
   // xor with current_value to bring it to zero
   // xor with address so the result will be address
-  gtable[free_slot][hashes[free_slot]]=gtable[free_slot][hashes[free_slot]]^current_value^address;
-  for (int i=0;i<k;i++) { // could do this in loop above, but intent probably clearer here
-    if (gtable_cnt[i][hashes[i]]!=GTABLE_MAX_COUNT) {
+  gtable[free_slot][hashes[free_slot]] = gtable[free_slot][hashes[free_slot]]^current_value^address;
+  for (int i = 0; i < k; i++) { // could do this in loop above, but intent probably clearer here
+    if (gtable_cnt[i][hashes[i]] != GTABLE_MAX_COUNT) {
       //printf("gtable: %d\n", gtable_cnt[i][hashes[i]]);
       gtable_cnt[i][hashes[i]]++;
       //printf("hashes[%d]: %d, gtable: %d\n", i, hashes[i], gtable_cnt[i][hashes[i]]);
@@ -321,27 +320,27 @@ void dmhc_t::real_insert(int address, meta_set_t *ops, meta_set_t *res, int *has
       //         (b) at beginning filling in all k
       //         (c) may end up conflicting with multiple hashes in victim
       //               so may be replacing in multiple
-    gtable_lastinsert[i][hashes[i]]=address;
+    gtable_lastinsert[i][hashes[i]] = address;
   }  
 }
 
-void dmhc_t::insert(meta_set_t *ops, meta_set_t *res, bool *consider) {
+void dmhc_t::insert(meta_set_t* ops, meta_set_t* res, bool* consider) {
   inserts++;
 #ifdef DMHC_DIRECT_K_HASH_CONFLICTS
-  check_direct_k_hash_conflicts(ops,consider);
+  check_direct_k_hash_conflicts(ops, consider);
 #endif
   
-  int mtable_entry=next_entry;
+  int mtable_entry = next_entry;
   next_entry++;
-  if (next_entry>=capacity)
-    next_entry=1; // skip 0=INVALID_LAST_USER   
+  if (next_entry >= capacity)
+    next_entry = 1; // skip 0=INVALID_LAST_USER   
 
-  if (mtable_use[mtable_entry]==true)
-    evict_mtable_entry(mtable_entry,victim_ops,victim_res,(int *)NULL); // capacity eviction -- we cannot save
+  if (mtable_use[mtable_entry] == true)
+    evict_mtable_entry(mtable_entry, victim_ops, victim_res, NULL); // capacity eviction -- we cannot save
   
-  compute_hashes(ops,do_not_victimize_hashes,consider);
+  compute_hashes(ops, do_not_victimize_hashes, consider);
 
-  insert(mtable_entry,ops,res,0,do_not_victimize_hashes,consider);
+  insert(mtable_entry, ops, res, 0, do_not_victimize_hashes, consider);
 #ifdef DMHC_DEBUG
   printf("ops - pc: %" PRItag ", ci: %" PRItag, ops[OP_PC].tags[0], ops[OP_CI].tags[0]);
   if (consider[OP_OP1]) printf(", op1: %" PRItag, ops[OP_OP1].tags[0]);
@@ -354,84 +353,84 @@ void dmhc_t::insert(meta_set_t *ops, meta_set_t *res, bool *consider) {
          victim_res[RES_CSR].tags[0], victim_res[PC_RES].tags[0], victim_res[RD_RES].tags[0],
          victim_res[CSR_RES].tags[0]);
 #endif
-  if (lookup(ops,victim_res,consider)!=true) {
+  if (lookup(ops, victim_res, consider) != true) {
     printf("lookup is not true\n");
     exit(1);
   } else {
-    bool match=true;
-    for (int i=0;i<output_fields;i++)
-      if (res[i].tags[0]!=victim_res[i].tags[0]) {
-        match=false;
+    bool match = true;
+    for (int i = 0; i < output_fields; i++)
+      if (res[i].tags[0] != victim_res[i].tags[0]) {
+        match = false;
         printf("victim res is not true\n");
         exit(1);
       }
-    if (match==false)
+    if (match == false)
       exit(1);
   }
 }
 
-void dmhc_t::insert(int mtable_address, meta_set_t *ops, meta_set_t *res, int hops, int *do_not_victimize, bool *consider) {
+void dmhc_t::insert(int mtable_address, meta_set_t* ops, meta_set_t* res, int hops, int* do_not_victimize, bool* consider) {
   // with care, this could use lookup as a subroutine
   //  would need to make address a return value (or part of the object representation)
-  int free_slot=-1;
-  bool victim=false;
+  int free_slot = -1;
+  bool victim = false;
 
-  int victim_address=-1;
+  int victim_address = -1;
 
-  compute_hashes(ops,hashes,consider);  
+  compute_hashes(ops, hashes, consider);  
 
   // 2/13/15 -- swapped this around so will take the lowest with 0 to match BSV
-  for (int i=k-1;i>-1;i--) {
-    if (gtable_cnt[i][hashes[i]]==0)
-      free_slot=i;
+  for (int i = k - 1; i > -1; i--) {
+    if (gtable_cnt[i][hashes[i]] == 0)
+      free_slot = i;
   }
-  if (free_slot==-1) {
+  if (free_slot == -1) {
     // try to identify thing to evict
-    int minuse=-1;
-    int minusers=-1;
-    for (int i=0;i<k;i++) {
-      if ((hops==0) || (hashes[i]!=do_not_victimize[i])) {
-        if (minuse==-1) {
-          minuse=i;
-          minusers=gtable_cnt[i][hashes[i]];
-        } else if (gtable_cnt[i][hashes[i]]<minusers) {
-        minuse=i;
-        minusers=gtable_cnt[i][hashes[i]];
+    int minuse = -1;
+    int minusers = -1;
+    for (int i = 0; i < k; i++) {
+      if ((hops == 0) || (hashes[i] != do_not_victimize[i])) {
+        if (minuse == -1) {
+          minuse = i;
+          minusers = gtable_cnt[i][hashes[i]];
+        } else if (gtable_cnt[i][hashes[i]] < minusers) {
+        minuse = i;
+        minusers = gtable_cnt[i][hashes[i]];
       }
     }
   }
     
 #ifdef DMHC_DIRECT_K_HASH_CONFLICTS_FROM_REINSERT 
-    if ((free_slot<0) && (minuse<0)) {
-      int tmp_mslot=INVALID_LAST_USER;
-      for (int f=0;f<k;f++)
-    if (gtable_lastinsert[f][hashes[f]]!=INVALID_LAST_USER)
-      tmp_mslot=gtable_lastinsert[f][hashes[f]];
-      bool real_conflict=false;
-      for (int j=0;j<input_fields;j++)
-    if (ops[j].tags[0]!=mtable_inputs[j][tmp_mslot].tags[0])
-      real_conflict=true;
+    if ((free_slot < 0) && (minuse < 0)) {
+      int tmp_mslot = INVALID_LAST_USER;
+      for (int f = 0; f < k; f++)
+    if (gtable_lastinsert[f][hashes[f]] != INVALID_LAST_USER)
+      tmp_mslot = gtable_lastinsert[f][hashes[f]];
+      bool real_conflict = false;
+      for (int j = 0; j < input_fields; j++)
+    if (ops[j].tags[0] != mtable_inputs[j][tmp_mslot].tags[0])
+      real_conflict = true;
     }
 #endif
 
-    if ((hops>0) && (minuse==-1)) {
+    if ((hops > 0) && (minuse == -1)) {
       // give up on re-inserting to avoid victimizing the thing that started the miss
       // go ahead and declare the victim slot we were trying to replace as dead
-      mtable_use[mtable_address]=false;     
+      mtable_use[mtable_address] = false;     
       return;
-    } else if ((hops==0) && (minuse==-1)) {
+    } else if ((hops == 0) && (minuse == -1)) {
       exit(3);
     } else {// we have a minuse>-1
-      if (gtable_lastinsert[minuse][hashes[minuse]]!=INVALID_LAST_USER) {
-        victim_address=gtable_lastinsert[minuse][hashes[minuse]];  
-        victim=true;
-        if (hops>0)
-          evict_mtable_entry(victim_address,victim_ops,victim_res,do_not_victimize); // conflict case -- try to reinsert
+      if (gtable_lastinsert[minuse][hashes[minuse]] != INVALID_LAST_USER) {
+        victim_address = gtable_lastinsert[minuse][hashes[minuse]];  
+        victim = true;
+        if (hops > 0)
+          evict_mtable_entry(victim_address, victim_ops, victim_res, do_not_victimize); // conflict case -- try to reinsert
         else // have not, yet, inserted the thing not to victimize
-          evict_mtable_entry(victim_address,victim_ops,victim_res,(int *)NULL); // conflict case -- try to reinsert
+          evict_mtable_entry(victim_address, victim_ops, victim_res, NULL); // conflict case -- try to reinsert
       } else {  
         // give up on evicting -- we will need to bash it anyway
-        victim=false; // should not be necessary, but making intent clear
+        victim = false; // should not be necessary, but making intent clear
       }
     }
 
@@ -441,19 +440,19 @@ void dmhc_t::insert(int mtable_address, meta_set_t *ops, meta_set_t *res, int ho
     //  So, in the case, we need to pick a slot and victimize it.
     // this time, we've aborted above if do_not_victimize prevents us from selecting an entry
     //   so there must be some entry to find.
-    minuse=-1;
-    minusers=-1;
-    for (int i=0;i<k;i++)
-      if ((hops==0) || (hashes[i]!=do_not_victimize[i])) {
-    if (minuse==-1) {
-      minuse=i;
-      minusers=gtable_cnt[i][hashes[i]];
-    } else if (gtable_cnt[i][hashes[i]]<minusers) {
-      minuse=i;
-      minusers=gtable_cnt[i][hashes[i]];
-    }
+    minuse = -1;
+    minusers = -1;
+    for (int i = 0; i < k; i++)
+      if ((hops == 0) || (hashes[i] != do_not_victimize[i])) {
+        if (minuse == -1) {
+          minuse = i;
+          minusers = gtable_cnt[i][hashes[i]];
+        } else if (gtable_cnt[i][hashes[i]] < minusers) {
+          minuse = i;
+          minusers = gtable_cnt[i][hashes[i]];
+        }
       }
-      free_slot=minuse;
+      free_slot = minuse;
   }
 #ifdef DMHC_DEBUG
   printf("mtable_address: %d, free_slot: %d\n", mtable_address, free_slot);
@@ -468,43 +467,43 @@ void dmhc_t::insert(int mtable_address, meta_set_t *ops, meta_set_t *res, int ho
          res[RES_CSR].tags[0], res[PC_RES].tags[0], res[RD_RES].tags[0],
          res[CSR_RES].tags[0]);
 #endif
-  real_insert(mtable_address,ops,res,hashes,free_slot,consider);
-  if (victim==true) {
-    if (hops<HOP_LIMIT) {
+  real_insert(mtable_address, ops, res, hashes, free_slot, consider);
+  if (victim == true) {
+    if (hops < HOP_LIMIT) {
       copy_victim_to_reinsert();
-      insert(victim_address,reinsert_ops,reinsert_res,hops+1,do_not_victimize,consider_evict);
+      insert(victim_address, reinsert_ops, reinsert_res, hops + 1, do_not_victimize, consider_evict);
     }
   } // if victim
 }
 
-bool dmhc_t::lookup(meta_set_t *ops, meta_set_t *res, bool *consider) {
-  compute_hashes(ops,hashes,consider); 
+bool dmhc_t::lookup(meta_set_t* ops, meta_set_t* res, bool* consider) {
+  compute_hashes(ops, hashes, consider); 
 #ifdef MISS_ON_ZERO_GTABLE_COUNT
   // see if it is a miss
-  for (int i=0;i<k;i++)
-    if (gtable_cnt[i][hashes[i]]==0) {      
+  for (int i = 0; i < k; i++)
+    if (gtable_cnt[i][hashes[i]] == 0) {      
       misses++;
       //printf("It is a miss\n");
       //printf(" -> k: %d, i: %d, hashes[i]: %d\n", k, i, hashes[i]);
-      return(false);
+      return false;
     }
 #endif
 
   // get the address
-  int addr=0;
-  for (int i=0;i<k;i++)
-    addr=addr^gtable[i][hashes[i]];   
+  int addr = 0;
+  for (int i = 0; i < k; i++)
+    addr = addr^gtable[i][hashes[i]];   
     
-  if (hit(ops,addr,consider)) { // check if real hit
+  if (hit(ops, addr, consider)) { // check if real hit
     // grab values
-    for (int i=0;i<output_fields;i++)
-      res[i].tags[0]=mtable_outputs[i][addr].tags[0];
+    for (int i = 0; i < output_fields; i++)
+      res[i].tags[0] = mtable_outputs[i][addr].tags[0];
     hits++;
-    return(true);
+    return true;
   } else { // false hit      
     false_hits++;
     //printf("It is a false hit\n");
-    return(false);
+    return false;
   }    
 }
 

--- a/validator/rule_cache/dmhc_rule_cache/dmhc.h
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc.h
@@ -3,6 +3,7 @@
 
 #include "compute_hash.h"
 #include "meta_cache.h"
+#include "riscv_isa.h"
 
 #define GTABLE_MAX_COUNT 3
 #define HOP_LIMIT 1
@@ -25,16 +26,16 @@ public:
   dmhc_t(int cap, int newk, int newc, int infields, int outfields, int* ops_size, int* res_size, bool new_no_evict, meta_set_cache_t* ms_cache);
   ~dmhc_t();
   void reset();
-  void insert(meta_set_t* ops, meta_set_t* res, bool* consider);
-  bool lookup(meta_set_t* ops, meta_set_t* res, bool* consider);
+  void insert(meta_set_t* ops, results_t& res, bool* consider);
+  bool lookup(meta_set_t* ops, results_t& res, bool* consider);
   void compute_hashes(meta_set_t* ops, int* hashes, bool* consider);
 
 private:
   void copy_victim_to_reinsert();
-  void insert(int address, meta_set_t* ops, meta_set_t* res, int hops, int* do_not_victimize, bool* consider);
-  void real_insert(int address, meta_set_t* ops, meta_set_t* res, int* hashes, int free_slot, bool* consider);
+  void insert(int address, meta_set_t* ops, results_t& res, int hops, int* do_not_victimize, bool* consider);
+  void real_insert(int address, meta_set_t* ops, results_t& res, int* hashes, int free_slot, bool* consider);
   bool hit(meta_set_t* ops, int address, bool* consider);
-  void evict_mtable_entry(int address, meta_set_t* victim_ops, meta_set_t* victim_res, int* do_not_victimize);
+  void evict_mtable_entry(int address, meta_set_t* victim_ops, results_t& victim_res, int* do_not_victimize);
   void check_direct_k_hash_conflicts(meta_set_t* ops, bool* consider); // goes with DMHC_DIRECT_K_HASH_CONFLICTS
 
   int capacity;
@@ -59,16 +60,16 @@ private:
   int** gtable_lastinsert;
   bool* mtable_use;
   meta_set_t** mtable_inputs;
-  meta_set_t** mtable_outputs;
+  results_t* mtable_outputs;
   bool** consider_mtable_input; //Used to keep track of don't care ops
 
   int **mtable_hashes; // not something we use in a real dMHC, but something to use to investigate a particular question
   //Q: how often do we get a direct conflict in all hashes? -- it should be extremely rare
 
   meta_set_t* victim_ops; // place to hold victims before reinsert
-  meta_set_t* victim_res; //  (perf. optimization to avoid reallocating)
+  results_t victim_res; //  (perf. optimization to avoid reallocating)
   meta_set_t* reinsert_ops; // place to hold victim during reinsertion (and not conflict with the victim it may produce)
-  meta_set_t* reinsert_res; //  (perf. optimization to avoid reallocating)
+  results_t reinsert_res; //  (perf. optimization to avoid reallocating)
   bool* consider_evict;
 
   int misses, hits, false_hits, direct_conflicts, inserts; // statistics

--- a/validator/rule_cache/dmhc_rule_cache/dmhc.h
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc.h
@@ -23,20 +23,20 @@ namespace policy_engine {
 
 class dmhc_t {
 public:
-  dmhc_t(int cap, int newk, int newc, int infields, int outfields, int* ops_size, int* res_size, bool new_no_evict, meta_set_cache_t* ms_cache);
+  dmhc_t(int cap, int newk, int newc, int infields, int outfields, int* ops_size, int* res_size, bool new_no_evict);
   ~dmhc_t();
   void reset();
-  void insert(meta_set_t* ops, results_t& res, bool* consider);
-  bool lookup(meta_set_t* ops, results_t& res, bool* consider);
-  void compute_hashes(meta_set_t* ops, int* hashes, bool* consider);
+  void insert(const operands_t& ops, results_t& res, bool* consider);
+  bool lookup(const operands_t& ops, results_t& res, bool* consider);
+  void compute_hashes(const operands_t& ops, int* hashes, bool* consider);
 
 private:
   void copy_victim_to_reinsert();
-  void insert(int address, meta_set_t* ops, results_t& res, int hops, int* do_not_victimize, bool* consider);
-  void real_insert(int address, meta_set_t* ops, results_t& res, int* hashes, int free_slot, bool* consider);
-  bool hit(meta_set_t* ops, int address, bool* consider);
-  void evict_mtable_entry(int address, meta_set_t* victim_ops, results_t& victim_res, int* do_not_victimize);
-  void check_direct_k_hash_conflicts(meta_set_t* ops, bool* consider); // goes with DMHC_DIRECT_K_HASH_CONFLICTS
+  void insert(int address, const operands_t& ops, results_t& res, int hops, int* do_not_victimize, bool* consider);
+  void real_insert(int address, const operands_t& ops, results_t& res, int* hashes, int free_slot, bool* consider);
+  bool hit(const operands_t& ops, int address, bool* consider);
+  void evict_mtable_entry(int address, operands_t& victim_ops, results_t& victim_res, int* do_not_victimize);
+  void check_direct_k_hash_conflicts(const operands_t& ops, bool* consider); // goes with DMHC_DIRECT_K_HASH_CONFLICTS
 
   int capacity;
   int k;
@@ -59,16 +59,16 @@ private:
   int** gtable_cnt;
   int** gtable_lastinsert;
   bool* mtable_use;
-  meta_set_t** mtable_inputs;
+  operands_t* mtable_inputs;
   results_t* mtable_outputs;
   bool** consider_mtable_input; //Used to keep track of don't care ops
 
   int **mtable_hashes; // not something we use in a real dMHC, but something to use to investigate a particular question
   //Q: how often do we get a direct conflict in all hashes? -- it should be extremely rare
 
-  meta_set_t* victim_ops; // place to hold victims before reinsert
+  operands_t victim_ops; // place to hold victims before reinsert
   results_t victim_res; //  (perf. optimization to avoid reallocating)
-  meta_set_t* reinsert_ops; // place to hold victim during reinsertion (and not conflict with the victim it may produce)
+  operands_t reinsert_ops; // place to hold victim during reinsertion (and not conflict with the victim it may produce)
   results_t reinsert_res; //  (perf. optimization to avoid reallocating)
   bool* consider_evict;
 

--- a/validator/rule_cache/dmhc_rule_cache/dmhc.h
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc.h
@@ -2,6 +2,7 @@
 #define __DMHC_H__
 
 #include "compute_hash.h"
+#include "meta_cache.h"
 
 #define GTABLE_MAX_COUNT 3
 #define HOP_LIMIT 1
@@ -21,54 +22,54 @@ namespace policy_engine {
 
 class dmhc_t {
 public:
-  dmhc_t(int cap, int newk, int newc, int infields, int outfields, int *ops_size, int *res_size, bool new_no_evict);
+  dmhc_t(int cap, int newk, int newc, int infields, int outfields, int* ops_size, int* res_size, bool new_no_evict, meta_set_cache_t* ms_cache);
   ~dmhc_t();
   void reset();
-  void insert(meta_set_t *ops, meta_set_t *res, bool *consider);
-  bool lookup(meta_set_t *ops, meta_set_t *res, bool *consider);
-  void compute_hashes(meta_set_t *ops, int *hashes, bool *consider);
+  void insert(meta_set_t* ops, meta_set_t* res, bool* consider);
+  bool lookup(meta_set_t* ops, meta_set_t* res, bool* consider);
+  void compute_hashes(meta_set_t* ops, int* hashes, bool* consider);
 
 private:
   void copy_victim_to_reinsert();
-  void insert(int address, meta_set_t *ops, meta_set_t *res, int hops, int *do_not_victimize, bool *consider);
-  void real_insert(int address, meta_set_t *ops, meta_set_t * res, int *hashes, int free_slot, bool *consider);
-  bool hit(meta_set_t *ops,int address,bool *consider);
-  void evict_mtable_entry(int address, meta_set_t *victim_ops, meta_set_t *victim_res, int *do_not_victimize);
-  void check_direct_k_hash_conflicts(meta_set_t *ops, bool *consider); // goes with DMHC_DIRECT_K_HASH_CONFLICTS
+  void insert(int address, meta_set_t* ops, meta_set_t* res, int hops, int* do_not_victimize, bool* consider);
+  void real_insert(int address, meta_set_t* ops, meta_set_t* res, int* hashes, int free_slot, bool* consider);
+  bool hit(meta_set_t* ops, int address, bool* consider);
+  void evict_mtable_entry(int address, meta_set_t* victim_ops, meta_set_t* victim_res, int* do_not_victimize);
+  void check_direct_k_hash_conflicts(meta_set_t* ops, bool* consider); // goes with DMHC_DIRECT_K_HASH_CONFLICTS
 
   int capacity;
   int k;
   int c;
   int input_fields;
   int output_fields;
-  int *input_field_widths;
-  int *output_field_widths;
-  
-  compute_hash_t *hasher;
+  int* input_field_widths;
+  int* output_field_widths;
+
+  compute_hash_t* hasher;
 
   bool no_evict;
   int next_entry;
 
-  int *hashes; // (perf. optimization to avoid reallocating)
-  int *victim_hashes; // similar optimization
-  int *do_not_victimize_hashes; // similar optimization
+  int* hashes; // (perf. optimization to avoid reallocating)
+  int* victim_hashes; // similar optimization
+  int* do_not_victimize_hashes; // similar optimization
   
-  int **gtable;
-  int **gtable_cnt;
-  int **gtable_lastinsert;
-  bool *mtable_use;
-  meta_set_t **mtable_inputs;
-  meta_set_t **mtable_outputs;
-  bool **consider_mtable_input; //Used to keep track of don't care ops
+  int** gtable;
+  int** gtable_cnt;
+  int** gtable_lastinsert;
+  bool* mtable_use;
+  meta_set_t** mtable_inputs;
+  meta_set_t** mtable_outputs;
+  bool** consider_mtable_input; //Used to keep track of don't care ops
 
   int **mtable_hashes; // not something we use in a real dMHC, but something to use to investigate a particular question
   //Q: how often do we get a direct conflict in all hashes? -- it should be extremely rare
 
-  meta_set_t *victim_ops; // place to hold victims before reinsert
-  meta_set_t *victim_res; //  (perf. optimization to avoid reallocating)
-  meta_set_t *reinsert_ops; // place to hold victim during reinsertion (and not conflict with the victim it may produce)
-  meta_set_t *reinsert_res; //  (perf. optimization to avoid reallocating)
-  bool *consider_evict;
+  meta_set_t* victim_ops; // place to hold victims before reinsert
+  meta_set_t* victim_res; //  (perf. optimization to avoid reallocating)
+  meta_set_t* reinsert_ops; // place to hold victim during reinsertion (and not conflict with the victim it may produce)
+  meta_set_t* reinsert_res; //  (perf. optimization to avoid reallocating)
+  bool* consider_evict;
 
   int misses, hits, false_hits, direct_conflicts, inserts; // statistics
 };

--- a/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.cc
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.cc
@@ -4,9 +4,7 @@
 
 namespace policy_engine {
 
-dmhc_rule_cache_t::dmhc_rule_cache_t(int capacity, int iwidth, int owidth, int k, bool no_evict, meta_set_cache_t* cache) {
-  ms_cache = cache;
-
+dmhc_rule_cache_t::dmhc_rule_cache_t(int capacity, int iwidth, int owidth, int k, bool no_evict) {
   int ops_size[OPS_LEN];
   ops_size[OP_PC] = iwidth;
   ops_size[OP_CI] = iwidth;
@@ -21,7 +19,7 @@ dmhc_rule_cache_t::dmhc_rule_cache_t(int capacity, int iwidth, int owidth, int k
   res_size[PC_RES] = owidth;
   res_size[RD_RES] = owidth;
   res_size[CSR_RES] = owidth;
-  the_rule_cache = new dmhc_t(capacity, k, 2, OPS_LEN, RES_LEN, ops_size, res_size, no_evict, cache);
+  the_rule_cache = new dmhc_t(capacity, k, 2, OPS_LEN, RES_LEN, ops_size, res_size, no_evict);
   consider[OP_PC] = true;
   consider[OP_CI] = true;
   consider[OP_OP1] = false;
@@ -34,11 +32,11 @@ void dmhc_rule_cache_t::install_rule(const operands_t& ops, const results_t& res
   res_copy = res;
 #ifdef DMHC_DEBUG
   printf("Install\n");
-  printf("ops - pc: %" PRIu32 ", ci: %" PRIu32, ops_copy[OP_PC].tags[0], ops_copy[OP_CI].tags[0]);
-  if (consider[OP_OP1]) printf(", op1: %" PRIu32, ops_copy[OP_OP1].tags[0]);
-  if (consider[OP_OP2]) printf(", op2: %" PRIu32, ops_copy[OP_OP2].tags[0]);
-  if (consider[OP_OP3]) printf(", op3: %" PRIu32, ops_copy[OP_OP3].tags[0]);
-  if (consider[OP_MEM]) printf(", mem: %" PRIu32, ops_copy[OP_MEM].tags[0]);
+  printf("ops - pc: %" PRItag ", ci: %" PRItag, ops_copy.pc, ops_copy.ci);
+  if (consider[OP_OP1]) printf(", op1: %" PRItag, ops_copy.op1);
+  if (consider[OP_OP2]) printf(", op2: %" PRItag, ops_copy.op2);
+  if (consider[OP_OP3]) printf(", op3: %" PRItag, ops_copy.op3);
+  if (consider[OP_MEM]) printf(", mem: %" PRItag, ops_copy.mem);
   printf("\n");
   printf("res - pc: %" PRItag ", rd: %" PRItag ", csr: %" PRItag ", pcRes: %" PRId32 ", rdRes: %"
          PRIu32 ", csrRes: %" PRIu32 "\n", res_copy.pc, res_copy.rd,  res_copy.csr,
@@ -48,40 +46,18 @@ void dmhc_rule_cache_t::install_rule(const operands_t& ops, const results_t& res
 }
 
 bool dmhc_rule_cache_t::allow(const operands_t& ops, results_t& res) {
-  ops_copy[OP_PC] = (*ms_cache)[ops.pc];
-  ops_copy[OP_CI] = (*ms_cache)[ops.ci];
-  if (ops.op1) {
-    ops_copy[OP_OP1] = (*ms_cache)[ops.op1];
-    consider[OP_OP1] = true;
-  } else {
-    consider[OP_OP1] = false;
-  }  
-  if (ops.op2) {
-    ops_copy[OP_OP2] = (*ms_cache)[ops.op2];
-    consider[OP_OP2] = true;
-  } else {
-    consider[OP_OP2] = false;
-  }  
-  if (ops.op3) {
-    ops_copy[OP_OP3] = (*ms_cache)[ops.op3];
-    consider[OP_OP3] = true;
-  } else {
-    consider[OP_OP3] = false;
-  }
-  if (ops.mem) {
-    ops_copy[OP_MEM] = (*ms_cache)[ops.mem];
-    consider[OP_MEM] = true;
-  }
-  else {
-    consider[OP_MEM] = false;
-  }
+  ops_copy = ops;
+  consider[OP_OP1] = ops.op1 != BAD_TAG_VALUE;
+  consider[OP_OP2] = ops.op2 != BAD_TAG_VALUE;
+  consider[OP_OP3] = ops.op3 != BAD_TAG_VALUE;
+  consider[OP_MEM] = ops.mem != BAD_TAG_VALUE;
 
 #ifdef DMHC_DEBUG
-  printf("Allow\nops - pc: %" PRIu32 ", ci: %" PRIu32, ops_copy[OP_PC].tags[0], ops_copy[OP_CI].tags[0]);
-  if (ops->op1) printf(", op1: %" PRIu32, ops_copy[OP_OP1].tags[0]);
-  if (ops->op2) printf(", op2: %" PRIu32, ops_copy[OP_OP2].tags[0]);
-  if (ops->op3) printf(", op3: %" PRIu32, ops_copy[OP_OP3].tags[0]);
-  if (ops->mem) printf(", mem: %" PRIu32, ops_copy[OP_MEM].tags[0]);
+  printf("Allow\nops - pc: %" PRItag ", ci: %" PRItag, ops_copy.pc, ops_copy.ci);
+  if (ops->op1) printf(", op1: %" PRItag, ops_copy.op1);
+  if (ops->op2) printf(", op2: %" PRItag, ops_copy.op2);
+  if (ops->op3) printf(", op3: %" PRItag, ops_copy.op3);
+  if (ops->mem) printf(", mem: %" PRItag, ops_copy.mem);
   printf("\n");
 #endif
 

--- a/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.cc
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.cc
@@ -1,6 +1,7 @@
 #include "dmhc_rule_cache.h"
 #include "meta_cache.h"
 #include "riscv_isa.h"
+#include "tag_types.h"
 
 namespace policy_engine {
 

--- a/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.cc
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.cc
@@ -33,9 +33,9 @@ dmhc_rule_cache_t::~dmhc_rule_cache_t() {
 }
 
 void dmhc_rule_cache_t::install_rule(const operands_t& ops, const results_t& res) {
-  res_copy[RES_PC] = *(*ms_cache)[res.pc];
-  res_copy[RES_RD] = *(*ms_cache)[res.rd];
-  res_copy[RES_CSR] = *(*ms_cache)[res.csr];
+  res_copy[RES_PC] = (*ms_cache)[res.pc];
+  res_copy[RES_RD] = (*ms_cache)[res.rd];
+  res_copy[RES_CSR] = (*ms_cache)[res.csr];
   res_copy[PC_RES].tags[0] = res.pcResult;
   res_copy[RD_RES].tags[0] = res.rdResult;
   res_copy[CSR_RES].tags[0] = res.csrResult;
@@ -56,28 +56,28 @@ void dmhc_rule_cache_t::install_rule(const operands_t& ops, const results_t& res
 }
 
 bool dmhc_rule_cache_t::allow(const operands_t& ops, results_t& res) {
-  ops_copy[OP_PC] = *(*ms_cache)[ops.pc];
-  ops_copy[OP_CI] = *(*ms_cache)[ops.ci];
+  ops_copy[OP_PC] = (*ms_cache)[ops.pc];
+  ops_copy[OP_CI] = (*ms_cache)[ops.ci];
   if (ops.op1) {
-    ops_copy[OP_OP1] = *(*ms_cache)[ops.op1];
+    ops_copy[OP_OP1] = (*ms_cache)[ops.op1];
     consider[OP_OP1] = true;
   } else {
     consider[OP_OP1] = false;
   }  
   if (ops.op2) {
-    ops_copy[OP_OP2] = *(*ms_cache)[ops.op2];
+    ops_copy[OP_OP2] = (*ms_cache)[ops.op2];
     consider[OP_OP2] = true;
   } else {
     consider[OP_OP2] = false;
   }  
   if (ops.op3) {
-    ops_copy[OP_OP3] = *(*ms_cache)[ops.op3];
+    ops_copy[OP_OP3] = (*ms_cache)[ops.op3];
     consider[OP_OP3] = true;
   } else {
     consider[OP_OP3] = false;
   }
   if (ops.mem) {
-    ops_copy[OP_MEM] = *(*ms_cache)[ops.mem];
+    ops_copy[OP_MEM] = (*ms_cache)[ops.mem];
     consider[OP_MEM] = true;
   }
   else {

--- a/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.cc
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.cc
@@ -29,13 +29,13 @@ dmhc_rule_cache_t::dmhc_rule_cache_t(int capacity, int iwidth, int owidth, int k
 dmhc_rule_cache_t::~dmhc_rule_cache_t() {
 }
 
-void dmhc_rule_cache_t::install_rule(const operands_t* ops, results_t* res) {
-  res_copy[RES_PC] = *res->pc;
-  res_copy[RES_RD] = *res->rd;
-  res_copy[RES_CSR] = *res->csr;
-  res_copy[PC_RES].tags[0] = res->pcResult;
-  res_copy[RD_RES].tags[0] = res->rdResult;
-  res_copy[CSR_RES].tags[0] = res->csrResult;
+void dmhc_rule_cache_t::install_rule(const operands_t& ops, const results_t& res) {
+  res_copy[RES_PC] = *res.pc;
+  res_copy[RES_RD] = *res.rd;
+  res_copy[RES_CSR] = *res.csr;
+  res_copy[PC_RES].tags[0] = res.pcResult;
+  res_copy[RD_RES].tags[0] = res.rdResult;
+  res_copy[CSR_RES].tags[0] = res.csrResult;
 #ifdef DMHC_DEBUG
   printf("Install\n");
   printf("ops - pc: %" PRIu32 ", ci: %" PRIu32, ops_copy[OP_PC].tags[0], ops_copy[OP_CI].tags[0]);
@@ -52,29 +52,29 @@ void dmhc_rule_cache_t::install_rule(const operands_t* ops, results_t* res) {
   the_rule_cache->insert(ops_copy, res_copy, consider);
 }
 
-bool dmhc_rule_cache_t::allow(const operands_t* ops, results_t* res) {
-  ops_copy[OP_PC] = *ops->pc;
-  ops_copy[OP_CI] = *ops->ci;
-  if (ops->op1) {
-    ops_copy[OP_OP1] = *ops->op1;
+bool dmhc_rule_cache_t::allow(const operands_t& ops, results_t& res) {
+  ops_copy[OP_PC] = *ops.pc;
+  ops_copy[OP_CI] = *ops.ci;
+  if (ops.op1) {
+    ops_copy[OP_OP1] = *ops.op1;
     consider[OP_OP1] = true;
   } else {
     consider[OP_OP1] = false;
   }  
-  if (ops->op2) {
-    ops_copy[OP_OP2] = *ops->op2;
+  if (ops.op2) {
+    ops_copy[OP_OP2] = *ops.op2;
     consider[OP_OP2] = true;
   } else {
     consider[OP_OP2] = false;
   }  
-  if (ops->op3) {
-    ops_copy[OP_OP3] = *ops->op3;
+  if (ops.op3) {
+    ops_copy[OP_OP3] = *ops.op3;
     consider[OP_OP3] = true;
   } else {
     consider[OP_OP3] = false;
   }
-  if (ops->mem) {
-    ops_copy[OP_MEM] = *ops->mem;
+  if (ops.mem) {
+    ops_copy[OP_MEM] = *ops.mem;
     consider[OP_MEM] = true;
   }
   else {
@@ -100,12 +100,12 @@ bool dmhc_rule_cache_t::allow(const operands_t* ops, results_t* res) {
 #ifdef DMHC_DEBUG
     printf("Found\n");
 #endif
-    res->pc = new meta_set_t{res_copy[RES_PC]};
-    res->rd = new meta_set_t{res_copy[RES_RD]};
-    res->csr = new meta_set_t{res_copy[RES_CSR]};
-    res->pcResult = res_copy[PC_RES].tags[0];
-    res->rdResult = res_copy[RD_RES].tags[0];
-    res->csrResult = res_copy[CSR_RES].tags[0];
+    res.pc = new meta_set_t{res_copy[RES_PC]};
+    res.rd = new meta_set_t{res_copy[RES_RD]};
+    res.csr = new meta_set_t{res_copy[RES_CSR]};
+    res.pcResult = res_copy[PC_RES].tags[0];
+    res.rdResult = res_copy[RD_RES].tags[0];
+    res.csrResult = res_copy[CSR_RES].tags[0];
     return true;
   }
 }

--- a/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.cc
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.cc
@@ -4,35 +4,35 @@ namespace policy_engine {
 
 dmhc_rule_cache_t::dmhc_rule_cache_t(int capacity, int iwidth, int owidth, int k, bool no_evict) {
   int ops_size[OPS_LEN];
-  ops_size[OP_PC]=iwidth;
-  ops_size[OP_CI]=iwidth;
-  ops_size[OP_OP1]=iwidth;
-  ops_size[OP_OP2]=iwidth;
-  ops_size[OP_OP3]=iwidth;
-  ops_size[OP_MEM]=iwidth;
+  ops_size[OP_PC] = iwidth;
+  ops_size[OP_CI] = iwidth;
+  ops_size[OP_OP1] = iwidth;
+  ops_size[OP_OP2] = iwidth;
+  ops_size[OP_OP3] = iwidth;
+  ops_size[OP_MEM] = iwidth;
   int res_size[RES_LEN];
-  res_size[RES_PC]=owidth;
-  res_size[RES_RD]=owidth;
-  res_size[RES_CSR]=owidth;
-  res_size[PC_RES]=owidth;
-  res_size[RD_RES]=owidth;
-  res_size[CSR_RES]=owidth;
+  res_size[RES_PC] = owidth;
+  res_size[RES_RD] = owidth;
+  res_size[RES_CSR] = owidth;
+  res_size[PC_RES] = owidth;
+  res_size[RD_RES] = owidth;
+  res_size[CSR_RES] = owidth;
   the_rule_cache = new dmhc_t(capacity, k, 2, OPS_LEN, RES_LEN, ops_size, res_size, no_evict);
-  consider[OP_PC]=true;
-  consider[OP_CI]=true;
-  consider[OP_OP1]=false;
-  consider[OP_OP2]=false;
-  consider[OP_OP3]=false;
-  consider[OP_MEM]=false;
+  consider[OP_PC] = true;
+  consider[OP_CI] = true;
+  consider[OP_OP1] = false;
+  consider[OP_OP2] = false;
+  consider[OP_OP3] = false;
+  consider[OP_MEM] = false;
 }
 
 dmhc_rule_cache_t::~dmhc_rule_cache_t() {
 }
 
-void dmhc_rule_cache_t::install_rule(operands_t *ops, results_t *res) {
-  res_copy[RES_PC]=*res->pc;
-  res_copy[RES_RD]=*res->rd;
-  res_copy[RES_CSR]=*res->csr;
+void dmhc_rule_cache_t::install_rule(const operands_t* ops, results_t* res) {
+  res_copy[RES_PC] = *res->pc;
+  res_copy[RES_RD] = *res->rd;
+  res_copy[RES_CSR] = *res->csr;
   res_copy[PC_RES].tags[0] = res->pcResult;
   res_copy[RD_RES].tags[0] = res->rdResult;
   res_copy[CSR_RES].tags[0] = res->csrResult;
@@ -52,34 +52,33 @@ void dmhc_rule_cache_t::install_rule(operands_t *ops, results_t *res) {
   the_rule_cache->insert(ops_copy, res_copy, consider);
 }
 
-bool dmhc_rule_cache_t::allow(operands_t *ops, results_t *res) {
-  ops_copy[OP_PC]=*ops->pc;
-  ops_copy[OP_CI]=*ops->ci;
+bool dmhc_rule_cache_t::allow(const operands_t* ops, results_t* res) {
+  ops_copy[OP_PC] = *ops->pc;
+  ops_copy[OP_CI] = *ops->ci;
   if (ops->op1) {
-    ops_copy[OP_OP1]=*ops->op1;
-    consider[OP_OP1]=true;
+    ops_copy[OP_OP1] = *ops->op1;
+    consider[OP_OP1] = true;
   } else {
-    consider[OP_OP1]=false;
+    consider[OP_OP1] = false;
   }  
   if (ops->op2) {
-    ops_copy[OP_OP2]=*ops->op2;
-    consider[OP_OP2]=true;
+    ops_copy[OP_OP2] = *ops->op2;
+    consider[OP_OP2] = true;
   } else {
-    consider[OP_OP2]=false;
+    consider[OP_OP2] = false;
   }  
   if (ops->op3) {
-    ops_copy[OP_OP3]=*ops->op3;
-    consider[OP_OP3]=true;
-  }
-  else {
-    consider[OP_OP3]=false;
+    ops_copy[OP_OP3] = *ops->op3;
+    consider[OP_OP3] = true;
+  } else {
+    consider[OP_OP3] = false;
   }
   if (ops->mem) {
-    ops_copy[OP_MEM]=*ops->mem;
-    consider[OP_MEM]=true;
+    ops_copy[OP_MEM] = *ops->mem;
+    consider[OP_MEM] = true;
   }
   else {
-    consider[OP_MEM]=false;
+    consider[OP_MEM] = false;
   }
 
 #ifdef DMHC_DEBUG
@@ -91,7 +90,7 @@ bool dmhc_rule_cache_t::allow(operands_t *ops, results_t *res) {
   printf("\n");
 #endif
 
-  bool found=the_rule_cache->lookup(ops_copy, res_copy, consider);
+  bool found = the_rule_cache->lookup(ops_copy, res_copy, consider);
   if (found == false) {
 #ifdef DMHC_DEBUG
     printf("Not found\n");

--- a/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.h
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include "base_rule_cache.h"
 #include "dmhc.h"
+#include "meta_cache.h"
 
 //#define DMHC_DEBUG 1
 
@@ -32,7 +33,7 @@ namespace policy_engine {
 class dmhc_rule_cache_t : public rule_cache_t {
 
 public:
-  dmhc_rule_cache_t(int capacity, int iwidth, int owidth, int k, bool no_evict);
+  dmhc_rule_cache_t(int capacity, int iwidth, int owidth, int k, bool no_evict, meta_set_cache_t* cache);
   ~dmhc_rule_cache_t();
 
   void install_rule(const operands_t& ops, const results_t& res); //Not used
@@ -40,6 +41,7 @@ public:
   void flush();
 
 private:
+  meta_set_cache_t* ms_cache;
   meta_set_t ops_copy[OPS_LEN];
   meta_set_t res_copy[RES_LEN];
   bool consider[OPS_LEN];

--- a/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.h
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.h
@@ -5,6 +5,7 @@
 #include "base_rule_cache.h"
 #include "dmhc.h"
 #include "meta_cache.h"
+#include "riscv_isa.h"
 
 //#define DMHC_DEBUG 1
 
@@ -34,7 +35,7 @@ class dmhc_rule_cache_t : public rule_cache_t {
 
 public:
   dmhc_rule_cache_t(int capacity, int iwidth, int owidth, int k, bool no_evict, meta_set_cache_t* cache);
-  ~dmhc_rule_cache_t();
+  ~dmhc_rule_cache_t() {}
 
   void install_rule(const operands_t& ops, const results_t& res); //Not used
   bool allow(const operands_t& ops, results_t& res);
@@ -43,9 +44,9 @@ public:
 private:
   meta_set_cache_t* ms_cache;
   meta_set_t ops_copy[OPS_LEN];
-  meta_set_t res_copy[RES_LEN];
+  results_t res_copy;
   bool consider[OPS_LEN];
-  dmhc_t *the_rule_cache;
+  dmhc_t* the_rule_cache;
 };
 
 } // namespace policy_engine

--- a/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.h
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.h
@@ -34,7 +34,7 @@ namespace policy_engine {
 class dmhc_rule_cache_t : public rule_cache_t {
 
 public:
-  dmhc_rule_cache_t(int capacity, int iwidth, int owidth, int k, bool no_evict, meta_set_cache_t* cache);
+  dmhc_rule_cache_t(int capacity, int iwidth, int owidth, int k, bool no_evict);
   ~dmhc_rule_cache_t() {}
 
   void install_rule(const operands_t& ops, const results_t& res); //Not used
@@ -42,8 +42,7 @@ public:
   void flush();
 
 private:
-  meta_set_cache_t* ms_cache;
-  meta_set_t ops_copy[OPS_LEN];
+  operands_t ops_copy;
   results_t res_copy;
   bool consider[OPS_LEN];
   dmhc_t* the_rule_cache;

--- a/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.h
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.h
@@ -35,8 +35,8 @@ public:
   dmhc_rule_cache_t(int capacity, int iwidth, int owidth, int k, bool no_evict);
   ~dmhc_rule_cache_t();
 
-  void install_rule(operands_t *ops, results_t *res); //Not used
-  bool allow(operands_t *ops, results_t *res);
+  void install_rule(const operands_t* ops, results_t* res); //Not used
+  bool allow(const operands_t* ops, results_t* res);
   void flush();
 
 private:

--- a/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.h
+++ b/validator/rule_cache/dmhc_rule_cache/dmhc_rule_cache.h
@@ -35,8 +35,8 @@ public:
   dmhc_rule_cache_t(int capacity, int iwidth, int owidth, int k, bool no_evict);
   ~dmhc_rule_cache_t();
 
-  void install_rule(const operands_t* ops, results_t* res); //Not used
-  bool allow(const operands_t* ops, results_t* res);
+  void install_rule(const operands_t& ops, const results_t& res); //Not used
+  bool allow(const operands_t& ops, results_t& res);
   void flush();
 
 private:

--- a/validator/rule_cache/finite_rule_cache/finite_rule_cache.cc
+++ b/validator/rule_cache/finite_rule_cache/finite_rule_cache.cc
@@ -6,37 +6,37 @@ namespace policy_engine {
 
 finite_rule_cache_t::finite_rule_cache_t(int capacity) : ideal_rule_cache_t() {
   this->capacity = capacity;
-  entries = (operands_t*) calloc(capacity, sizeof(operands_t));
+  entries = new operands_t[capacity];
   next_entry = 0;
   cache_full = false;
 }
 
 finite_rule_cache_t::~finite_rule_cache_t() {
-  delete entries;
+  delete[] entries;
 }
 
-void finite_rule_cache_t::install_rule(operands_t *ops, results_t *res) {
-  if(cache_full) {
+void finite_rule_cache_t::install_rule(const operands_t* ops, results_t* res) {
+  if (cache_full) {
     auto existing_entry = rule_cache_table.find(entries[next_entry]);
-    if ((existing_entry==rule_cache_table.end())) {
+    if ((existing_entry == rule_cache_table.end())) {
       printf("Internal error in rule cache - do not trust results.\n");
     } else {
       rule_cache_table.erase(existing_entry);
     }
   }
   auto new_entry = rule_cache_table.insert(std::make_pair(*ops, *res));
-  memcpy(entries+next_entry, ops, sizeof(operands_t));
+  memcpy(entries + next_entry, ops, sizeof(operands_t));
 
   next_entry++;
-  if(next_entry>=capacity) {
+  if (next_entry >= capacity) {
     cache_full = true;
     next_entry=0;
   }
 }
 
-bool finite_rule_cache_t::allow(operands_t *ops, results_t *res) {
+bool finite_rule_cache_t::allow(const operands_t* ops, results_t* res) {
   auto existing_entry = rule_cache_table.find(*ops);
-  if (!(existing_entry == rule_cache_table.end())) {
+  if (existing_entry != rule_cache_table.end()) {
     *res->pc = *existing_entry->second.pc;
     *res->rd = *existing_entry->second.rd;
     *res->csr = *existing_entry->second.csr;
@@ -44,7 +44,7 @@ bool finite_rule_cache_t::allow(operands_t *ops, results_t *res) {
     res->rdResult = existing_entry->second.rdResult;
     res->csrResult = existing_entry->second.csrResult;
   }
-  return !(existing_entry == rule_cache_table.end());
+  return existing_entry != rule_cache_table.end();
 }
 
 } // namespace policy_engine

--- a/validator/rule_cache/finite_rule_cache/finite_rule_cache.cc
+++ b/validator/rule_cache/finite_rule_cache/finite_rule_cache.cc
@@ -4,45 +4,34 @@
 
 namespace policy_engine {
 
-finite_rule_cache_t::finite_rule_cache_t(int capacity) : ideal_rule_cache_t() {
-  this->capacity = capacity;
-  entries = new operands_t[capacity];
-  next_entry = 0;
-  cache_full = false;
-}
-
-finite_rule_cache_t::~finite_rule_cache_t() {
-  delete[] entries;
-}
-
-void finite_rule_cache_t::install_rule(const operands_t* ops, results_t* res) {
+void finite_rule_cache_t::install_rule(const operands_t& ops, const results_t& res) {
   if (cache_full) {
     auto existing_entry = rule_cache_table.find(entries[next_entry]);
-    if ((existing_entry == rule_cache_table.end())) {
+    if (existing_entry == rule_cache_table.end()) {
       printf("Internal error in rule cache - do not trust results.\n");
     } else {
       rule_cache_table.erase(existing_entry);
     }
   }
-  auto new_entry = rule_cache_table.insert(std::make_pair(*ops, *res));
-  memcpy(entries + next_entry, ops, sizeof(operands_t));
+  rule_cache_table[ops] = res;
+  entries[next_entry] = ops;
 
   next_entry++;
   if (next_entry >= capacity) {
     cache_full = true;
-    next_entry=0;
+    next_entry = 0;
   }
 }
 
-bool finite_rule_cache_t::allow(const operands_t* ops, results_t* res) {
-  auto existing_entry = rule_cache_table.find(*ops);
+bool finite_rule_cache_t::allow(const operands_t& ops, results_t& res) {
+  auto existing_entry = rule_cache_table.find(ops);
   if (existing_entry != rule_cache_table.end()) {
-    res->pc = existing_entry->second.pc;
-    res->rd = existing_entry->second.rd;
-    res->csr = existing_entry->second.csr;
-    res->pcResult = existing_entry->second.pcResult;
-    res->rdResult = existing_entry->second.rdResult;
-    res->csrResult = existing_entry->second.csrResult;
+    res.pc = existing_entry->second.pc;
+    res.rd = existing_entry->second.rd;
+    res.csr = existing_entry->second.csr;
+    res.pcResult = existing_entry->second.pcResult;
+    res.rdResult = existing_entry->second.rdResult;
+    res.csrResult = existing_entry->second.csrResult;
   }
   return existing_entry != rule_cache_table.end();
 }

--- a/validator/rule_cache/finite_rule_cache/finite_rule_cache.cc
+++ b/validator/rule_cache/finite_rule_cache/finite_rule_cache.cc
@@ -37,9 +37,9 @@ void finite_rule_cache_t::install_rule(const operands_t* ops, results_t* res) {
 bool finite_rule_cache_t::allow(const operands_t* ops, results_t* res) {
   auto existing_entry = rule_cache_table.find(*ops);
   if (existing_entry != rule_cache_table.end()) {
-    *res->pc = *existing_entry->second.pc;
-    *res->rd = *existing_entry->second.rd;
-    *res->csr = *existing_entry->second.csr;
+    res->pc = existing_entry->second.pc;
+    res->rd = existing_entry->second.rd;
+    res->csr = existing_entry->second.csr;
     res->pcResult = existing_entry->second.pcResult;
     res->rdResult = existing_entry->second.rdResult;
     res->csrResult = existing_entry->second.csrResult;

--- a/validator/rule_cache/finite_rule_cache/finite_rule_cache.h
+++ b/validator/rule_cache/finite_rule_cache/finite_rule_cache.h
@@ -3,21 +3,19 @@
 
 #include <functional>
 #include <unordered_map>
+#include <vector>
 #include "ideal_rule_cache.h"
 #include "riscv_isa.h"
 
 namespace policy_engine {
 
-class finite_rule_cache_t : public ideal_rule_cache_t
-{
-
+class finite_rule_cache_t : public ideal_rule_cache_t {
 public:
+  finite_rule_cache_t(int capacity) : ideal_rule_cache_t(), capacity(capacity), cache_full(false), entries(std::vector<operands_t>(capacity)), next_entry(0) {}
+  ~finite_rule_cache_t() {}
 
-  finite_rule_cache_t(int capacity);
-  ~finite_rule_cache_t();
-
-  void install_rule(const operands_t* ops, results_t* res);
-  bool allow(const operands_t* ops, results_t* res);
+  void install_rule(const operands_t& ops, const results_t& res);
+  bool allow(const operands_t& ops, results_t& res);
 
 private:
   // the number of rules the cache can hold.
@@ -32,7 +30,7 @@ private:
   // The oldest entry in the cache is:
   //   - entries[0] if cache_full is false
   //   - entries[(next_entry+1)%capacity] if cache_full is true
-  operands_t* entries;
+  std::vector<operands_t> entries;
 
   // the next location into which we will insert an entry in the "entries"
   // array.

--- a/validator/rule_cache/finite_rule_cache/finite_rule_cache.h
+++ b/validator/rule_cache/finite_rule_cache/finite_rule_cache.h
@@ -16,8 +16,8 @@ public:
   finite_rule_cache_t(int capacity);
   ~finite_rule_cache_t();
 
-  void install_rule(operands_t *ops, results_t *res);
-  bool allow(operands_t *ops, results_t *res);
+  void install_rule(const operands_t* ops, results_t* res);
+  bool allow(const operands_t* ops, results_t* res);
 
 private:
   // the number of rules the cache can hold.
@@ -32,7 +32,7 @@ private:
   // The oldest entry in the cache is:
   //   - entries[0] if cache_full is false
   //   - entries[(next_entry+1)%capacity] if cache_full is true
-  operands_t *entries;
+  operands_t* entries;
 
   // the next location into which we will insert an entry in the "entries"
   // array.

--- a/validator/rule_cache/ideal_rule_cache/ideal_rule_cache.cc
+++ b/validator/rule_cache/ideal_rule_cache/ideal_rule_cache.cc
@@ -22,9 +22,9 @@ void ideal_rule_cache_t::install_rule(const operands_t* ops, results_t* res) {
 bool ideal_rule_cache_t::allow(const operands_t* ops, results_t* res) {
   auto entries = rule_cache_table.find(*ops);
   if (entries != rule_cache_table.end()) {
-    *res->pc = *entries->second.pc;
-    *res->rd = *entries->second.rd;
-    *res->csr = *entries->second.csr;
+    res->pc = entries->second.pc;
+    res->rd = entries->second.rd;
+    res->csr = entries->second.csr;
     res->pcResult = entries->second.pcResult;
     res->rdResult = entries->second.rdResult;
     res->csrResult = entries->second.csrResult;

--- a/validator/rule_cache/ideal_rule_cache/ideal_rule_cache.cc
+++ b/validator/rule_cache/ideal_rule_cache/ideal_rule_cache.cc
@@ -15,13 +15,13 @@ ideal_rule_cache_t::~ideal_rule_cache_t() {
   flush();
 }
 
-void ideal_rule_cache_t::install_rule(operands_t *ops, results_t *res) {
+void ideal_rule_cache_t::install_rule(const operands_t* ops, results_t* res) {
   rule_cache_table.insert(std::make_pair(*ops, *res));
 }
 
-bool ideal_rule_cache_t::allow(operands_t *ops, results_t *res) {
+bool ideal_rule_cache_t::allow(const operands_t* ops, results_t* res) {
   auto entries = rule_cache_table.find(*ops);
-  if (!(entries == rule_cache_table.end())) {
+  if (entries != rule_cache_table.end()) {
     *res->pc = *entries->second.pc;
     *res->rd = *entries->second.rd;
     *res->csr = *entries->second.csr;
@@ -29,7 +29,7 @@ bool ideal_rule_cache_t::allow(operands_t *ops, results_t *res) {
     res->rdResult = entries->second.rdResult;
     res->csrResult = entries->second.csrResult;
   }
-  return !(entries == rule_cache_table.end());
+  return entries != rule_cache_table.end();
 }
 
 }

--- a/validator/rule_cache/ideal_rule_cache/ideal_rule_cache.cc
+++ b/validator/rule_cache/ideal_rule_cache/ideal_rule_cache.cc
@@ -15,19 +15,19 @@ ideal_rule_cache_t::~ideal_rule_cache_t() {
   flush();
 }
 
-void ideal_rule_cache_t::install_rule(const operands_t* ops, results_t* res) {
-  rule_cache_table.insert(std::make_pair(*ops, *res));
+void ideal_rule_cache_t::install_rule(const operands_t& ops, const results_t& res) {
+  rule_cache_table[ops] = res;
 }
 
-bool ideal_rule_cache_t::allow(const operands_t* ops, results_t* res) {
-  auto entries = rule_cache_table.find(*ops);
+bool ideal_rule_cache_t::allow(const operands_t& ops, results_t& res) {
+  auto entries = rule_cache_table.find(ops);
   if (entries != rule_cache_table.end()) {
-    res->pc = entries->second.pc;
-    res->rd = entries->second.rd;
-    res->csr = entries->second.csr;
-    res->pcResult = entries->second.pcResult;
-    res->rdResult = entries->second.rdResult;
-    res->csrResult = entries->second.csrResult;
+    res.pc = entries->second.pc;
+    res.rd = entries->second.rd;
+    res.csr = entries->second.csr;
+    res.pcResult = entries->second.pcResult;
+    res.rdResult = entries->second.rdResult;
+    res.csrResult = entries->second.csrResult;
   }
   return entries != rule_cache_table.end();
 }

--- a/validator/rule_cache/ideal_rule_cache/ideal_rule_cache.h
+++ b/validator/rule_cache/ideal_rule_cache/ideal_rule_cache.h
@@ -16,12 +16,12 @@ public:
   ideal_rule_cache_t();
   ~ideal_rule_cache_t();
 
-  void install_rule(const operands_t* ops, results_t* res);
-  bool allow(const operands_t* ops, results_t* res);
+  void install_rule(const operands_t& ops, const results_t& res);
+  bool allow(const operands_t& ops, results_t& res);
   void flush();
 
 protected:
-  std::unordered_map<operands_t, results_t, std::hash<operands_t>, compare_ops> rule_cache_table;
+  std::unordered_map<operands_t, results_t> rule_cache_table;
 };
 
 } // namespace policy_engine

--- a/validator/rule_cache/ideal_rule_cache/ideal_rule_cache.h
+++ b/validator/rule_cache/ideal_rule_cache/ideal_rule_cache.h
@@ -16,8 +16,8 @@ public:
   ideal_rule_cache_t();
   ~ideal_rule_cache_t();
 
-  void install_rule(operands_t *ops, results_t *res);
-  bool allow(operands_t *ops, results_t *res);
+  void install_rule(const operands_t* ops, results_t* res);
+  bool allow(const operands_t* ops, results_t* res);
   void flush();
 
 protected:

--- a/validator/src/soc_tag_configuration.cc
+++ b/validator/src/soc_tag_configuration.cc
@@ -79,7 +79,7 @@ void soc_tag_configuration_t::process_element(const std::string& element_name, c
   if (n["heterogeneous"]) {
     elt.heterogeneous = n["heterogeneous"].as<bool>();
   }
-  elt.meta_set = factory->get_meta_set(elt_path);
+  elt.tag = factory->get_tag(elt_path);
   elements.push_back(elt);
 }
 
@@ -97,9 +97,9 @@ soc_tag_configuration_t::soc_tag_configuration_t(meta_set_factory_t* factory, co
 void soc_tag_configuration_t::apply(tag_bus_t* tag_bus, meta_set_cache_t* ms_cache) {
   for (const auto& e: elements) {
     if (e.heterogeneous) {
-      tag_bus->add_provider(e.start, e.end, std::make_unique<platform_ram_tag_provider_t>(e.end - e.start, ms_cache->tag_of(e.meta_set), e.word_size, e.tag_granularity));
+      tag_bus->add_provider(e.start, e.end, std::make_unique<platform_ram_tag_provider_t>(e.end - e.start, e.tag, e.word_size, e.tag_granularity));
     } else {
-      tag_bus->add_provider(e.start, e.end, std::make_unique<uniform_tag_provider_t>(e.end - e.start, ms_cache->tag_of(e.meta_set), e.tag_granularity));
+      tag_bus->add_provider(e.start, e.end, std::make_unique<uniform_tag_provider_t>(e.end - e.start, e.tag, e.tag_granularity));
     }
   }
 }

--- a/validator/src/soc_tag_configuration.cc
+++ b/validator/src/soc_tag_configuration.cc
@@ -97,9 +97,9 @@ soc_tag_configuration_t::soc_tag_configuration_t(meta_set_factory_t* factory, co
 void soc_tag_configuration_t::apply(tag_bus_t* tag_bus, meta_set_cache_t* ms_cache) {
   for (const auto& e: elements) {
     if (e.heterogeneous) {
-      tag_bus->add_provider(e.start, e.end, std::make_unique<platform_ram_tag_provider_t>(e.end - e.start, ms_cache->to_tag(e.meta_set), e.word_size, e.tag_granularity));
+      tag_bus->add_provider(e.start, e.end, std::make_unique<platform_ram_tag_provider_t>(e.end - e.start, ms_cache->tag_of(e.meta_set), e.word_size, e.tag_granularity));
     } else {
-      tag_bus->add_provider(e.start, e.end, std::make_unique<uniform_tag_provider_t>(e.end - e.start, ms_cache->to_tag(e.meta_set), e.tag_granularity));
+      tag_bus->add_provider(e.start, e.end, std::make_unique<uniform_tag_provider_t>(e.end - e.start, ms_cache->tag_of(e.meta_set), e.tag_granularity));
     }
   }
 }


### PR DESCRIPTION
Rather than tags being pointers and depending on them being in particular memory locations, along with dangerous casting between pointer and integer types, tags should be indices into a metadata table.

At the moment, because meta sets have to be mutable due to the way they are handled in the policy evaluation and simulated rule cache code, meta set equality has to be checked by identity instead of value. This means that a `std::vector` is not an appropriate data structure to use for storing them, as `std::vector` moves its contents when it has to resize to store a new item. Instead, `std::list` has to be used along with a map of index onto a pointer into the list, because `std::list` doesn't allow random access.

Requires #77 to be merged first.